### PR TITLE
Make Consumer a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Or install it yourself as:
 Add a file in e.g. `app/consumers/user_ban_consumer.rb`:
 
 ```ruby
-class UserBanConsumer < Racecar::Consumer
+class UserBanConsumer
+  extend Racecar::Consumer
+
   subscribes_to "user_banned"
 
   def process(message)

--- a/examples/cat_consumer.rb
+++ b/examples/cat_consumer.rb
@@ -1,4 +1,6 @@
-class CatConsumer < Racecar::Consumer
+class CatConsumer
+  extend Racecar::Consumer
+
   subscribes_to "messages", start_from_beginning: false
 
   def process(message)

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -1,20 +1,18 @@
 module Racecar
-  class Consumer
+  module Consumer
     Subscription = Struct.new(:topic, :start_from_beginning)
 
-    class << self
-      attr_accessor :max_wait_time
-      attr_accessor :group_id
+    attr_accessor :max_wait_time
+    attr_accessor :group_id
 
-      def subscriptions
-        @subscriptions ||= []
-      end
+    def subscriptions
+      @subscriptions ||= []
+    end
 
-      # Adds one or more topic subscriptions.
-      def subscribes_to(*topics, start_from_beginning: true)
-        topics.each do |topic|
-          subscriptions << Subscription.new(topic, start_from_beginning)
-        end
+    # Adds one or more topic subscriptions.
+    def subscribes_to(*topics, start_from_beginning: true)
+      topics.each do |topic|
+        subscriptions << Subscription.new(topic, start_from_beginning)
       end
     end
   end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,6 +1,8 @@
 require "stringio"
 
-class TestConsumer < Racecar::Consumer
+class TestConsumer
+  extend Racecar::Consumer
+
   attr_reader :messages
 
   def initialize


### PR DESCRIPTION
We probably don't need to make Racecar::Consumer a base class. Would it be better to use `extend Racecar::Consumer`?