### PR TITLE
Only load Rails application if Rails is available

### DIFF
--- a/exe/racecar
+++ b/exe/racecar
@@ -24,21 +24,27 @@ config_file = "config/racecar.yml"
 
 puts "=> Starting Racecar consumer #{consumer_name}..."
 
-puts "=> Booting Rails application..."
+begin
+  require "rails"
 
-require "./config/environment"
+  puts "=> Detected Rails, booting application..."
 
-Racecar.config.load_file(config_file, Rails.env)
+  require "./config/environment"
 
-if Racecar.config.log_to_stdout
-  # Write to STDOUT as well as to the log file.
-  console = ActiveSupport::Logger.new($stdout)
-  console.formatter = Rails.logger.formatter
-  console.level = Rails.logger.level
-  Rails.logger.extend(ActiveSupport::Logger.broadcast(console))
+  Racecar.config.load_file(config_file, Rails.env)
+
+  if Racecar.config.log_to_stdout
+    # Write to STDOUT as well as to the log file.
+    console = ActiveSupport::Logger.new($stdout)
+    console.formatter = Rails.logger.formatter
+    console.level = Rails.logger.level
+    Rails.logger.extend(ActiveSupport::Logger.broadcast(console))
+  end
+
+  Racecar.logger = Rails.logger
+rescue LoadError
+  # Not a Rails application.
 end
-
-Racecar.logger = Rails.logger
 
 # Find the consumer class by name.
 consumer_class = Kernel.const_get(consumer_name)


### PR DESCRIPTION
Before, Rails was required in order to boot a consumer. Now we try to load Rails, but if it fails we'll just continue with our business.