### PR TITLE
Allow configuring the max number of bytes to fetch

### DIFF
--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -1,6 +1,6 @@
 module Racecar
   class Consumer
-    Subscription = Struct.new(:topic, :start_from_beginning)
+    Subscription = Struct.new(:topic, :start_from_beginning, :max_bytes_per_partition)
 
     class << self
       attr_accessor :max_wait_time
@@ -11,9 +11,14 @@ module Racecar
       end
 
       # Adds one or more topic subscriptions.
-      def subscribes_to(*topics, start_from_beginning: true)
+      #
+      # start_from_beginning    - whether to start from the beginning or the end of each
+      #                           partition.
+      # max_bytes_per_partition - the maximum number of bytes to fetch from each partition
+      #                           at a time.
+      def subscribes_to(*topics, start_from_beginning: true, max_bytes_per_partition: 1048576)
         topics.each do |topic|
-          subscriptions << Subscription.new(topic, start_from_beginning)
+          subscriptions << Subscription.new(topic, start_from_beginning, max_bytes_per_partition)
         end
       end
     end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -29,10 +29,11 @@ module Racecar
       trap("INT") { consumer.stop }
 
       config.subscriptions.each do |subscription|
-        topic = subscription.topic
-        start_from_beginning = subscription.start_from_beginning
-
-        consumer.subscribe(topic, start_from_beginning: start_from_beginning)
+        consumer.subscribe(
+          subscription.topic,
+          start_from_beginning: subscription.start_from_beginning,
+          max_bytes_per_partition: subscription.max_bytes_per_partition,
+        )
       end
 
       begin


### PR DESCRIPTION
This is configured on a per topic basis and applies to the number of bytes fetched from a single partition.