### PR TITLE
Handle SIGTERM in addition to SIGQUIT and SIGINT

### DIFF
--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -24,9 +24,10 @@ module Racecar
         heartbeat_interval: config.heartbeat_interval,
       )
 
-      # Stop the consumer on SIGINT and SIGQUIT.
+      # Stop the consumer on SIGINT, SIGQUIT or SIGTERM.
       trap("QUIT") { consumer.stop }
       trap("INT") { consumer.stop }
+      trap("TERM") { consumer.stop }
 
       config.subscriptions.each do |subscription|
         consumer.subscribe(


### PR DESCRIPTION
SIGTERM is sent when the consumers are about to be reload.
Should finish processing the current message.

@dasch Please review

cc @libo