### PR TITLE
Validate that no unknown env variables have been set

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -162,6 +162,8 @@ module Racecar
       loader.integer(:connect_timeout)
       loader.integer(:socket_timeout)
       loader.integer(:max_wait_time)
+
+      loader.validate!
     end
   end
 end

--- a/lib/racecar/env_loader.rb
+++ b/lib/racecar/env_loader.rb
@@ -3,6 +3,7 @@ module Racecar
     def initialize(env, config)
       @env = env
       @config = config
+      @loaded_keys = []
     end
 
     def string(name)
@@ -23,6 +24,16 @@ module Racecar
       set(name) {|value| value.split(",") }
     end
 
+    def validate!
+      # Make sure the user hasn't made a typo and added a key we don't know
+      # about.
+      @env.keys.grep(/^RACECAR_/).each do |key|
+        unless @loaded_keys.include?(key)
+          raise ConfigError, "unknown config variable #{key}"
+        end
+      end
+    end
+
     private
 
     def set(name)
@@ -31,6 +42,7 @@ module Racecar
       if @env.key?(key)
         value = yield @env.fetch(key)
         @config.set(name, value)
+        @loaded_keys << key
       end
     end
   end

--- a/spec/env_loader_spec.rb
+++ b/spec/env_loader_spec.rb
@@ -1,0 +1,25 @@
+require "racecar/env_loader"
+
+describe Racecar::EnvLoader do
+  let(:env) { {} }
+  let(:config) { double(:config, set: nil) }
+  let(:loader) { Racecar::EnvLoader.new(env, config) }
+
+  describe "#validate!" do
+    it "raises ConfigError if an unknown RACECAR_* env variable is set" do
+      env["RACECAR_HELLO"] = "world"
+
+      expect {
+        loader.validate!
+      }.to raise_error(Racecar::ConfigError, "unknown config variable RACECAR_HELLO")
+    end
+
+    it "doesn't raise an error if all RACECAR_* env variables are valid" do
+      env["RACECAR_HELLO"] = "world"
+
+      loader.string(:hello)
+
+      expect { loader.validate! }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
There's a risk that a user may typo an environment variable name and expect that the config is applied when in fact we'd be using the default value. This makes Racecar crash on startup if unknown environment variables starting with `RACECAR_` are set.