### PR TITLE
Allow daemonizing the process

### DIFF
--- a/exe/racecarctl
+++ b/exe/racecarctl
@@ -7,6 +7,5 @@ begin
   Racecar::Ctl.main(ARGV)
 rescue Racecar::Error => e
   $stderr.puts "Error: #{e.message}"
-  $stderr.puts "Run `racecarctl produce -h` to see valid options"
   exit 1
 end

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -70,6 +70,12 @@ module Racecar
     desc "The password used to authenticate"
     string :sasl_plain_password
 
+    desc "The file in which to store the Racecar process' PID when daemonized"
+    string :pidfile
+
+    desc "Run the Racecar process in the background as a daemon"
+    boolean :daemonize, default: false
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 
@@ -115,6 +121,7 @@ module Racecar
 
       self.subscriptions = consumer_class.subscriptions
       self.max_wait_time = consumer_class.max_wait_time || self.max_wait_time
+      self.pidfile ||= "#{group_id}.pid"
     end
 
     def on_error(&handler)

--- a/lib/racecar/daemon.rb
+++ b/lib/racecar/daemon.rb
@@ -1,0 +1,97 @@
+module Racecar
+  class Daemon
+    attr_reader :pidfile
+
+    def initialize(pidfile)
+      raise Racecar::Error, "No pidfile specified" if pidfile.nil?
+
+      @pidfile = pidfile
+    end
+
+    def pidfile?
+      !pidfile.nil?
+    end
+
+    def daemonize!
+      exit if fork
+      Process.setsid
+      exit if fork
+      Dir.chdir "/"
+    end
+
+    def redirect_output(logfile)
+      FileUtils.mkdir_p(File.dirname(logfile), mode: 0755)
+      FileUtils.touch(logfile)
+
+      File.chmod(0644, logfile)
+
+      $stderr.reopen(logfile, 'a')
+      $stdout.reopen($stderr)
+      $stdout.sync = $stderr.sync = true
+    end
+
+    def suppress_input
+      $stdin.reopen('/dev/null')
+    end
+
+    def suppress_output
+      $stderr.reopen('/dev/null', 'a')
+      $stdout.reopen($stderr)
+    end
+
+    def check_pid
+      if pidfile?
+        case pid_status
+        when :running, :not_owned
+          $stderr.puts "=> Racecar is already running with that PID file (#{pidfile})"
+          exit(1)
+        when :dead
+          File.delete(pidfile)
+        end
+      end
+    end
+
+    def pid
+      if File.exists?(pidfile)
+        File.read(pidfile).to_i
+      else
+        nil
+      end
+    end
+
+    def running?
+      pid_status == :running || pid_status == :not_owned
+    end
+
+    def stop!
+      Process.kill("TERM", pid)
+    end
+
+    def pid_status
+      return :exited if pid.nil?
+      return :dead if pid == 0
+
+      # This will raise Errno::ESRCH if the process doesn't exist.
+      Process.kill(0, pid)
+
+      :running
+    rescue Errno::ESRCH
+      :dead
+    rescue Errno::EPERM
+      :not_owned
+    end
+
+    def write_pid
+      File.open(pidfile, ::File::CREAT | ::File::EXCL | ::File::WRONLY) do |f|
+        f.write(Process.pid.to_s)
+      end
+
+      at_exit do
+        File.delete(pidfile) if File.exists?(pidfile)
+      end
+    rescue Errno::EEXIST
+      check_pid
+      retry
+    end
+  end
+end


### PR DESCRIPTION
Allow daemonizing the Racecar process. When executing `racecar` with the `--daemonize` flag, the process will fork off and do the daemonic dance in order to liberate itself from its terminal master. The process id (PID) of the new process will be written to a (configurable) file, which will allow tools to identify the process and send it signals. The `racecarctl` tool gets two new commands, `status` and `stop`.

Based on http://codeincomplete.com/posts/ruby-daemons/

This is done in order to support users who do not want to use process managers such as Runit or God. A Capistrano recipe could be added to automate the process management.

#### Tasks

- [x] Should we keep a PID file per consumer class and have `racecarctl` take a consumer class argument? For example, `racecarctl stop EchoConsumer`?