### PR TITLE
Allow configuring a log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ If you've ever used Heroku you'll recognize the format – indeed, deploying to 
 With Foreman, you can easily run these processes locally by executing `foreman run`; in production you'll want to _export_ to another process management format such as Upstart or Runit. [capistrano-foreman](https://github.com/hyperoslo/capistrano-foreman) allows you to do this with Capistrano.
 
 
+### Logging
+
+By default, Racecar will log to `STDOUT`. If you're using Rails, your application code will use whatever logger you've configured there.
+
+In order to make Racecar log its own operations to a log file, set the `logfile` configuration variable or pass `--log filename.log` to the `racecar` command.
+
+
 ### Operations
 
 In order to gracefully shut down a Racecar consumer process, send it the `SIGTERM` signal. Most process supervisors such as Runit and Kubernetes send this signal when shutting down a process, so using those systems will make things easier.

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -1,4 +1,5 @@
 require "optparse"
+require "logger"
 require "racecar/rails_config_file_loader"
 
 module Racecar
@@ -9,6 +10,10 @@ module Racecar
 
         opts.on("-r", "--require LIBRARY", "Require the LIBRARY before starting the consumer") do |lib|
           require lib
+        end
+
+        opts.on("-l", "--log LOGFILE", "Log to the specified file") do |logfile|
+          Racecar.config.logfile = logfile
         end
 
         opts.on_tail("--version", "Show Racecar version") do
@@ -33,6 +38,11 @@ module Racecar
       Racecar.config.load_consumer_class(consumer_class)
 
       Racecar.config.validate!
+
+      if Racecar.config.logfile
+        puts "=> Logging to #{Racecar.config.logfile}"
+        Racecar.logger = Logger.new(Racecar.config.logfile)
+      end
 
       puts "=> Wrooooom!"
       puts "=> Ctrl-C to shutdown consumer"

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -21,7 +21,7 @@ module Racecar
       max_wait_time
 
       error_handler
-      log_to_stdout
+      logfile
 
       ssl_ca_cert
       ssl_ca_cert_file_path
@@ -43,7 +43,6 @@ module Racecar
     DEFAULT_CONFIG = {
       brokers: ["localhost:9092"],
       client_id: "racecar",
-      group_id_prefix: nil,
 
       subscriptions: [],
 
@@ -72,9 +71,6 @@ module Racecar
 
       # Default is to do nothing on exceptions.
       error_handler: proc {},
-
-      # Default is to only log to the logger.
-      log_to_stdout: false,
     }
 
     attr_accessor(*ALLOWED_KEYS)

--- a/lib/racecar/rails_config_file_loader.rb
+++ b/lib/racecar/rails_config_file_loader.rb
@@ -12,15 +12,14 @@ module Racecar
 
         Racecar.config.load_file(config_file, Rails.env)
 
-        if Racecar.config.log_to_stdout
-          # Write to STDOUT as well as to the log file.
+        # In development, write Rails logs to STDOUT. This mirrors what e.g.
+        # Unicorn does.
+        if Rails.env.development?
           console = ActiveSupport::Logger.new($stdout)
           console.formatter = Rails.logger.formatter
           console.level = Rails.logger.level
           Rails.logger.extend(ActiveSupport::Logger.broadcast(console))
         end
-
-        Racecar.logger = Rails.logger
       rescue LoadError
         # Not a Rails application.
       end


### PR DESCRIPTION
* Don't write to the Rails log by default.
* Default to logging on `STDOUT`.
* Allow passing in `--log LOGFILE` to configure the log file.