### PR TITLE
call `stop` on consumer class when trapping signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,30 @@ end
 
 An important detail is that, if an exception is raised while processing a batch, the _whole batch_ is re-processed.
 
+#### Teardown
+
+When a consumer is stopped with `QUIT`, `INT`, or `TERM` signal, consumer's `teardown` method is called.
+
+```ruby
+class ConsumerWithTeardown < Racecar::Consumer
+  subscribes_to "events"
+
+  def initialize
+    @my_connection = MyConnection.new
+  end
+
+  def process(message)
+    puts message.value
+  end
+
+  def teardown
+    @my_connection.close
+  end
+end
+```
+
+This is useful for ie. closing connections or invoking some additional logic for consumers (like storing state to a file).
+
 ### Running consumers
 
 Racecar is first and foremost an executable _consumer runner_. The `racecar` executable takes as argument the name of the consumer class that should be run. Racecar automatically loads your Rails application before starting, and you can load any other library you need by passing the `--require` flag, e.g.

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -22,5 +22,7 @@ module Racecar
         end
       end
     end
+
+    def teardown; end
   end
 end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -8,8 +8,8 @@ module Racecar
       @processor, @config, @logger = processor, config, logger
     end
 
-    def stop
-      processor.stop if processor.respond_to?(:stop)
+    def teardown
+      processor.teardown
       consumer.stop
     end
 
@@ -33,9 +33,9 @@ module Racecar
       )
 
       # Stop the consumer on SIGINT, SIGQUIT or SIGTERM.
-      trap("QUIT") { stop }
-      trap("INT") { stop }
-      trap("TERM") { stop }
+      trap("QUIT") { teardown }
+      trap("INT") { teardown }
+      trap("TERM") { teardown }
 
       # Print the consumer config to STDERR on USR1.
       trap("USR1") { $stderr.puts config.inspect }

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -21,11 +21,6 @@ class TestConsumer < Racecar::Consumer
   end
 end
 
-class TestStopConsumer < TestConsumer
-  def stop; end
-  def process(message); end
-end
-
 class TestBatchConsumer < Racecar::Consumer
   attr_reader :messages
 
@@ -222,8 +217,8 @@ describe Racecar::Runner do
     end
   end
 
-  context "#stop" do
-    let(:processor) { TestStopConsumer.new }
+  context "#teardown" do
+    let(:processor) { TestConsumer.new }
 
     before :each do
       @signal_handler = Signal.trap("TERM", "SYSTEM_DEFAULT")
@@ -233,11 +228,10 @@ describe Racecar::Runner do
       Signal.trap("TERM", @signal_handler)
     end
 
-    context "given consumer class with #stop method" do
-      it "calls consumers class #stop method" do
+    context "given consumer class with #teardown method" do
+      it "calls consumers class #teardown method" do
         pid = fork do
-          expect(processor).to receive(:stop)
-          expect(kafka).to receive(:stop)
+          expect(processor).to receive(:teardown)
 
           runner.run
 
@@ -248,7 +242,6 @@ describe Racecar::Runner do
 
     it "calls kafka #stop method" do
       pid = fork do
-        expect(processor).to receive(:stop)
         expect(kafka).to receive(:stop)
 
         runner.run


### PR DESCRIPTION
As we're rewriting our consumers we've noticed that there's one case we can't handle with racecar right now. Some of our consumer do some cleanup when a consumer is being shut down. This PR would allow us to have the same behaviour in racecar.