### PR TITLE
Allow setting the consumer group session timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The consumers will checkpoint their positions from time to time in order to be a
 
 All timeouts are defined in number of seconds.
 
+* `session_timeout` – The idle timeout after which a consumer is kicked out of the group. Consumers must send heartbeats with at least this frequency.
 * `heartbeat_interval` – How often to send a heartbeat message to Kafka.
 * `pause_timeout` – How long to pause a partition for if the consumer raises an exception while processing a message. Default is to pause for 10 seconds. Set this to zero in order to disable automatic pausing of partitions.
 * `connect_timeout` – How long to wait when trying to connect to a Kafka broker. Default is 10 seconds.

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -11,6 +11,7 @@ module Racecar
       offset_commit_interval
       offset_commit_threshold
 
+      session_timeout
       heartbeat_interval
       pause_timeout
       connect_timeout
@@ -57,6 +58,9 @@ module Racecar
 
       # Default is to pause partitions for 10 seconds on processing errors.
       pause_timeout: 10,
+
+      # Default is to kick consumers out of a group after 30 seconds without activity.
+      session_timeout: 30,
 
       # Default is to allow at most 10 seconds when connecting to a broker.
       connect_timeout: 10,

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -29,6 +29,7 @@ module Racecar
         group_id: config.group_id,
         offset_commit_interval: config.offset_commit_interval,
         offset_commit_threshold: config.offset_commit_threshold,
+        session_timeout: config.session_timeout,
         heartbeat_interval: config.heartbeat_interval,
       )
 


### PR DESCRIPTION
Useful if e.g. your consumer groups have trouble stabilizing.