### PR TITLE
Allow configuring Racecar through the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Racecar has support for using SASL to authenticate clients using either the GSSA
 
 If using GSSAPI:
 
-* `sasl_gssapi_principal` – The GSSAPI principal
+* `sasl_gssapi_principal` – The GSSAPI principal.
 * `sasl_gssapi_keytab` – Optional GSSAPI keytab.
 
 If using PLAIN:

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -16,9 +16,27 @@ module Racecar
           Racecar.config.logfile = logfile
         end
 
+        Racecar::Config.variables.each do |variable|
+          opt_name = "--" << variable.name.to_s.gsub("_", "-") << " VALUE"
+          desc = variable.description || "N/A"
+
+          if variable.default
+            desc << " (default: #{variable.default.inspect})"
+          end
+
+          opts.on(opt_name, desc) do |value|
+            Racecar.config.decode(variable.name, value)
+          end
+        end
+
         opts.on_tail("--version", "Show Racecar version") do
           require "racecar/version"
           $stderr.puts "Racecar #{Racecar::VERSION}"
+          exit
+        end
+
+        opts.on_tail("-h", "--help", "Show this message") do
+          puts opts
           exit
         end
       end

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -10,8 +10,6 @@ module Racecar
     desc "A string used to identify the client in logs and metrics"
     string :client_id, default: "racecar"
 
-    list :subscriptions, default: []
-
     desc "How frequently to commit offset positions"
     integer :offset_commit_interval, default: 10
 
@@ -75,9 +73,12 @@ module Racecar
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 
+    attr_accessor :subscriptions
+
     def initialize(env: ENV)
       super(env: env)
       @error_handler = proc {}
+      @subscriptions = []
     end
 
     def inspect

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -4,51 +4,73 @@ module Racecar
   class Config < KingKonf::Config
     prefix :racecar
 
+    desc "A list of Kafka brokers in the cluster that you're consuming from"
     list :brokers, default: ["localhost:9092"]
+
+    desc "A string used to identify the client in logs and metrics"
     string :client_id, default: "racecar"
 
     list :subscriptions, default: []
 
-    # Default is to commit offsets every 10 seconds.
+    desc "How frequently to commit offset positions"
     integer :offset_commit_interval, default: 10
 
-    # Default is no buffer threshold trigger.
+    desc "How many messages to process before forcing a checkpoint"
     integer :offset_commit_threshold, default: 0
 
-    # Default is to send a heartbeat every 10 seconds.
+    desc "How often to send a heartbeat message to Kafka"
     integer :heartbeat_interval, default: 10
 
-    # Default is to pause partitions for 10 seconds on processing errors.
+    desc "How long to pause a partition for if the consumer raises an exception while processing a message"
     integer :pause_timeout, default: 10
 
-    # Default is to kick consumers out of a group after 30 seconds without activity.
+    desc "The idle timeout after which a consumer is kicked out of the group"
     integer :session_timeout, default: 30
 
-    # Default is to allow at most 10 seconds when connecting to a broker.
+    desc "How long to wait when trying to connect to a Kafka broker"
     integer :connect_timeout, default: 10
 
-    # Default is to allow at most 30 seconds when reading or writing to
-    # a broker socket.
+    desc "How long to wait when trying to communicate with a Kafka broker"
     integer :socket_timeout, default: 30
 
-    # Default is to allow the brokers up to 5 seconds before returning
-    # messages.
+    desc "How long to allow the Kafka brokers to wait before returning messages"
     integer :max_wait_time, default: 5
 
+    desc "A prefix used when generating consumer group names"
     string :group_id_prefix
+
+    desc "The group id to use for a given group of consumers"
     string :group_id
 
+    desc "A filename that log messages should be written to"
     string :logfile
 
+    desc "A valid SSL certificate authority"
     string :ssl_ca_cert
+
+    desc "The path to a valid SSL certificate authority file"
     string :ssl_ca_cert_file_path
+
+    desc "A valid SSL client certificate"
     string :ssl_client_cert
+
+    desc "A valid SSL client certificate key"
     string :ssl_client_cert_key
 
+    desc "The GSSAPI principal"
     string :sasl_gssapi_principal
+
+    desc "Optional GSSAPI keytab"
     string :sasl_gssapi_keytab
+
+    desc "The authorization identity to use"
     string :sasl_plain_authzid
+
+    desc "The username used to authenticate"
     string :sasl_plain_username
+
+    desc "The password used to authenticate"
+    string :sasl_plain_password
 
     # The error handler must be set directly on the object.
     attr_reader :error_handler

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "king_konf", "~> 0.1.4"
+  spec.add_runtime_dependency "king_konf", "~> 0.1.5"
   spec.add_runtime_dependency "ruby-kafka", "~> 0.4"
 
   spec.add_development_dependency "bundler", "~> 1.13"


### PR DESCRIPTION
Allow setting config variables through the CLI:

```
$ bundle exec racecar --help                                                                                                                               cli-config
Usage: racecar MyConsumer [options]
    -r, --require LIBRARY            Require the LIBRARY before starting the consumer
    -l, --log LOGFILE                Log to the specified file
        --brokers VALUE              A list of Kafka brokers in the cluster that you're consuming from (default: ["localhost:9092"])
        --client-id VALUE            A string used to identify the client in logs and metrics (default: "racecar")
        --offset-commit-interval VALUE
                                     How frequently to commit offset positions (default: 10)
        --offset-commit-threshold VALUE
                                     How many messages to process before forcing a checkpoint (default: 0)
        --heartbeat-interval VALUE   How often to send a heartbeat message to Kafka (default: 10)
        --pause-timeout VALUE        How long to pause a partition for if the consumer raises an exception while processing a message (default: 10)
        --session-timeout VALUE      The idle timeout after which a consumer is kicked out of the group (default: 30)
        --connect-timeout VALUE      How long to wait when trying to connect to a Kafka broker (default: 10)
        --socket-timeout VALUE       How long to wait when trying to communicate with a Kafka broker (default: 30)
        --max-wait-time VALUE        How long to allow the Kafka brokers to wait before returning messages (default: 5)
        --group-id-prefix VALUE      A prefix used when generating consumer group names
        --group-id VALUE             The group id to use for a given group of consumers
        --logfile VALUE              A filename that log messages should be written to
        --ssl-ca-cert VALUE          A valid SSL certificate authority
        --ssl-ca-cert-file-path VALUE
                                     The path to a valid SSL certificate authority file
        --ssl-client-cert VALUE      A valid SSL client certificate
        --ssl-client-cert-key VALUE  A valid SSL client certificate key
        --sasl-gssapi-principal VALUE
                                     The GSSAPI principal
        --sasl-gssapi-keytab VALUE   Optional GSSAPI keytab
        --sasl-plain-authzid VALUE   The authorization identity to use
        --sasl-plain-username VALUE  The username used to authenticate
        --sasl-plain-password VALUE  The password used to authenticate
        --version                    Show Racecar version
    -h, --help                       Show this message
```