### PR TITLE
Rescue SignalException at the top level

### DIFF
--- a/exe/racecar
+++ b/exe/racecar
@@ -7,6 +7,13 @@ $LOAD_PATH.unshift(Dir.pwd)
 
 begin
   Racecar::Cli.main(ARGV)
+rescue SignalException => e
+  # We might receive SIGTERM before our signal handler is installed.
+  if Signal.signame(e.signo) == "TERM"
+    exit(0)
+  else
+    raise
+  end
 rescue
   exit(1)
 else


### PR DESCRIPTION
We might receive SIGTERM before we've had a chance to install our signal handler, resulting in the exception being raised. This gracefully handles that scenario.