### PR TITLE
Allow configuring Racecar with Ruby

### DIFF
--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -15,6 +15,10 @@ module Racecar
     @config ||= Config.new
   end
 
+  def self.configure
+    yield config
+  end
+
   def self.logger
     @logger ||= Logger.new(STDOUT)
   end

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -25,6 +25,10 @@ module Racecar
 
       RailsConfigFileLoader.load!
 
+      if File.exist?("config/racecar.rb")
+        require "config/racecar"
+      end
+
       # Find the consumer class by name.
       consumer_class = Kernel.const_get(consumer_name)
 


### PR DESCRIPTION
* Automatically loads `config/racecar.rb` if it exists.
* Adds a nicer syntax for configuring in Ruby.

Now you can just do this:

```ruby
# config/racecar.rb
Racecar.configure do |config|
  config.session_timeout = 10

  # Provide a default value if e.g. no ENV var has been provided
  # and there's no Racecar default:
  config.group_id ||= "some-group"
end
```