### PR TITLE
Fix log_level

### DIFF
--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -43,7 +43,7 @@ module Racecar
       end
 
       if config.log_level
-        Racecar.logger.level = config.log_level
+        Racecar.logger.level = Object.const_get("Logger::#{config.log_level.upcase}")
       end
 
       if config.datadog_enabled


### PR DESCRIPTION
`logger.level=` expects INT, not a String