### PR TITLE
Allow passing through already setup statsd client

### DIFF
--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -141,10 +141,15 @@ module Racecar
       require "kafka/datadog"
 
       datadog = Kafka::Datadog
-      datadog.host = config.datadog_host if config.datadog_host.present?
-      datadog.port = config.datadog_port if config.datadog_port.present?
-      datadog.namespace = config.datadog_namespace if config.datadog_namespace.present?
-      datadog.tags = config.datadog_tags if config.datadog_tags.present?
+
+      if config.statsd.present?
+        datadog.statsd = config.statsd
+      else
+        datadog.host = config.datadog_host if config.datadog_host.present?
+        datadog.port = config.datadog_port if config.datadog_port.present?
+        datadog.namespace = config.datadog_namespace if config.datadog_namespace.present?
+        datadog.tags = config.datadog_tags if config.datadog_tags.present?
+      end
     end
   end
 end

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -145,5 +145,7 @@ module Racecar
     def on_error(&handler)
       @error_handler = handler
     end
+
+    attr_accessor :statsd
   end
 end


### PR DESCRIPTION
Paired with https://github.com/zendesk/ruby-kafka/pull/500 this PR lets you set the `Kafka::Datadog.statsd` client to an already configure statsd client.