### PR TITLE
Fix `consumer_class` instrumentation field

### DIFF
--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -54,7 +54,7 @@ module Racecar
         if processor.respond_to?(:process)
           consumer.each_message(max_wait_time: config.max_wait_time) do |message|
             payload = {
-              consumer_class: processor.to_s,
+              consumer_class: processor.class.to_s,
               topic: message.topic,
               partition: message.partition,
               offset: message.offset,
@@ -71,7 +71,7 @@ module Racecar
         elsif processor.respond_to?(:process_batch)
           consumer.each_batch(max_wait_time: config.max_wait_time) do |batch|
             payload = {
-              consumer_class: processor.to_s,
+              consumer_class: processor.class.to_s,
               topic: batch.topic,
               partition: batch.partition,
               first_offset: batch.first_offset,


### PR DESCRIPTION
This PR fixes the `consumer_class` instrumentation param provided to the `instrumenter`. 

All event subscribers should now receive a `consumer_class` field that looks like `FooConsumer` instead of `#<FooConsumer:0x007ff7bf7cc3b0>`.