### PR TITLE
Pass ssl_ca_cert_file_path config to Kafka.new in runner.rb

### DIFF
--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -22,6 +22,7 @@ module Racecar
         connect_timeout: config.connect_timeout,
         socket_timeout: config.socket_timeout,
         ssl_ca_cert: config.ssl_ca_cert,
+        ssl_ca_cert_file_path: config.ssl_ca_cert_file_path,
         ssl_client_cert: config.ssl_client_cert,
         ssl_client_cert_key: config.ssl_client_cert_key,
         sasl_plain_username: config.sasl_plain_username,


### PR DESCRIPTION
It looks like the `ssl_ca_cert_file_path` option was missed in the runner - this fixes the issue.