### PR TITLE
Support for producing messages from #process / #process_batch return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Use the optional `responds_with:` option to specify a topic to produce messages 
 `#process` or `#process_batch` method will be the message produced. If the return value is `nil`, no message
 will be produced.
 
-The `response_partition_key:` may be used to specify a partition key or a method pointer (symbol). When using a method,
-the message or batch will be passed to the method and it's return used as the partition key for the message produced.
+`response_partition_key:` may be used to specify a partition key or a method pointer (symbol) to determine the
+partition key used when producing the response.
 
 ```ruby
 class AddUserIdConsumer < Racecar::Consumer

--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -1,6 +1,7 @@
 require "logger"
-
+require "delivery_boy"
 require "racecar/consumer"
+require "racecar/producer"
 require "racecar/runner"
 require "racecar/config"
 
@@ -24,6 +25,8 @@ module Racecar
 
   def self.configure
     yield config
+    config.configure_delivery_boy!
+    config
   end
 
   def self.logger

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -94,6 +94,9 @@ module Racecar
     desc "Tags that should always be set on Datadog metrics"
     list :datadog_tags
 
+    desc "Configure DeliveryBoy with Racecar's settings"
+    boolean :configure_delivery_boy, default: true
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 
@@ -144,6 +147,18 @@ module Racecar
 
     def on_error(&handler)
       @error_handler = handler
+    end
+
+    def configure_delivery_boy!
+      return unless configure_delivery_boy
+      # Configure DeliveryBoy with same configuration as Racecar
+      DeliveryBoy.configure do |config|
+        self.class.variables.each do |variable|
+          name = variable.name
+          value = send(name)
+          config.send("#{name}=", value) if config.respond_to?(name) && !value.nil?
+        end
+      end
     end
   end
 end

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -20,7 +20,7 @@ module Racecar
       # responds_with           - optional topic to which the return value of the #process or #process_batch method
       #                           is produced
       # response_partition_key  - optional string or method pointer (symbol) to use as the partition key for messages
-      #                           produced, message or batch will be passed to method
+      #                           produced
       def subscribes_to(*topics, start_from_beginning: true, max_bytes_per_partition: 1048576, responds_with: nil,
                         response_partition_key: nil)
         topics.each do |topic|

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -1,6 +1,7 @@
 module Racecar
   class Consumer
-    Subscription = Struct.new(:topic, :start_from_beginning, :max_bytes_per_partition)
+    Subscription = Struct.new(:topic, :start_from_beginning, :max_bytes_per_partition, :responds_with,
+                              :response_partition_key)
 
     class << self
       attr_accessor :max_wait_time
@@ -16,9 +17,15 @@ module Racecar
       #                           partition.
       # max_bytes_per_partition - the maximum number of bytes to fetch from each partition
       #                           at a time.
-      def subscribes_to(*topics, start_from_beginning: true, max_bytes_per_partition: 1048576)
+      # responds_with           - optional topic to which the return value of the #process or #process_batch method
+      #                           is produced
+      # response_partition_key  - optional string or method pointer (symbol) to use as the partition key for messages
+      #                           produced, message or batch will be passed to method
+      def subscribes_to(*topics, start_from_beginning: true, max_bytes_per_partition: 1048576, responds_with: nil,
+                        response_partition_key: nil)
         topics.each do |topic|
-          subscriptions << Subscription.new(topic, start_from_beginning, max_bytes_per_partition)
+          subscriptions << Subscription.new(topic, start_from_beginning, max_bytes_per_partition, responds_with,
+                                            response_partition_key)
         end
       end
     end

--- a/lib/racecar/producer.rb
+++ b/lib/racecar/producer.rb
@@ -1,0 +1,9 @@
+module Racecar
+  module Producer
+    class << self
+      def produce(topic, message, options = {})
+        DeliveryBoy.deliver(message, options.merge({ topic: topic }))
+      end
+    end
+  end
+end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -22,6 +22,7 @@ module Racecar
         connect_timeout: config.connect_timeout,
         socket_timeout: config.socket_timeout,
         ssl_ca_cert: config.ssl_ca_cert,
+        ssl_ca_cert_file_path: config.ssl_ca_cert_file_path,
         ssl_client_cert: config.ssl_client_cert,
         ssl_client_cert_key: config.ssl_client_cert_key,
         sasl_plain_username: config.sasl_plain_username,

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "king_konf", "~> 0.1.9"
+  spec.add_runtime_dependency "delivery_boy", "~> 0.2"
   spec.add_runtime_dependency "ruby-kafka", "~> 0.4"
 
   spec.add_development_dependency "bundler", "~> 1.13"

--- a/spec/racecar_spec.rb
+++ b/spec/racecar_spec.rb
@@ -1,0 +1,27 @@
+require "racecar/config"
+
+describe Racecar do
+  describe ".configure" do
+    let!(:original_config) { Racecar.config }
+    let(:new_brokers) { ["foo", "bar"] }
+
+    before { allow(DeliveryBoy).to receive(:configure).and_call_original }
+    after { Racecar.instance_variable_set(:@config, original_config) }
+
+    it "configures DeliveryBoy as well" do
+      Racecar.configure { |c| c.brokers = new_brokers }
+      expect(DeliveryBoy).to have_received(:configure)
+      expect(DeliveryBoy.config.brokers).to eq new_brokers
+    end
+
+    context "config.configure_delivery_boy set to false" do
+      it "does not configure DeliveryBoy" do
+        Racecar.configure do |c|
+          c.brokers = new_brokers
+          c.configure_delivery_boy = false
+        end
+        expect(DeliveryBoy).not_to have_received(:configure)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[#29] This PR adds support for a common use case where a consumer needs to process messages from one topic and produce messages on another. Examples include data transformation or "responding" to another service that a message has been processed.

#### Producing responses

Use the optional `responds_with:` option to specify a topic to produce messages to. The return value from the `#process` or `#process_batch` method will be the message produced. If the return value is `nil`, no message will be produced.

`response_partition_key:` may be used to specify a partition key or a method pointer (symbol) to determine the partition key used when producing the response.

```ruby
class AddUserIdConsumer < Racecar::Consumer
  subscribes_to "visitors", responds_with: "visitors_user_id", response_partition_key: :transformed_partition_key
  
  def process(message)
    data = JSON.parse(message.value)
    user = User.find_by(email: data['email'])]
    return unless user
    
    data['user_id'] = user.id
    @partition_key = user.account_id
    data.to_json
  end
  
  def transformed_partition_key
    @partition_key
  end
end
``` 