### PR TITLE
Allow producing messages

### DIFF
--- a/examples/producing_consumer.rb
+++ b/examples/producing_consumer.rb
@@ -1,0 +1,9 @@
+class ProducingConsumer < Racecar::Consumer
+  subscribes_to "messages", start_from_beginning: false
+
+  def process(message)
+    value = message.value.reverse
+
+    produce value, topic: "reverse-messages"
+  end
+end

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -23,6 +23,16 @@ module Racecar
       end
     end
 
+    def configure(producer:)
+      @_producer = producer
+    end
+
     def teardown; end
+
+    protected
+
+    def produce(value, topic:)
+      @_producer.produce(value, topic: topic)
+    end
   end
 end


### PR DESCRIPTION
This change allows consumers to produce messages. The messages will be delivered automatically after `#process` returns, in the case of single-message processing, or after `#process_batch` returns, in the case of batch processing.

The API works like this:

```ruby
class DoublingConsumer < Racecar::Consumer
  subscribes_to "numbers"

  def process(message)
    value = Integer(message.value)

    # The #produce method buffers up a message to be delivered to Kafka.
    # Racecar handles the actual delivery after #process returns.
    produce value * 2, topic: "doubled"
  end
end
```

Closes #29.