### PR TITLE
Change the default max_wait_time to 1 second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Change the default `max_wait_time` to 1 second.
+
 ## racecar v0.3.7
 
 * Allow setting the key and/or partition key when producing messages.

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ All timeouts are defined in number of seconds.
 * `pause_timeout` – How long to pause a partition for if the consumer raises an exception while processing a message. Default is to pause for 10 seconds. Set this to zero in order to disable automatic pausing of partitions.
 * `connect_timeout` – How long to wait when trying to connect to a Kafka broker. Default is 10 seconds.
 * `socket_timeout` – How long to wait when trying to communicate with a Kafka broker. Default is 30 seconds.
-* `max_wait_time` – How long to allow the Kafka brokers to wait before returning messages. A higher number means larger batches, at the cost of higher latency. Default is 5 seconds.
+* `max_wait_time` – How long to allow the Kafka brokers to wait before returning messages. A higher number means larger batches, at the cost of higher latency. Default is 1 second.
 
 #### SSL encryption, authentication & authorization
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -32,7 +32,7 @@ module Racecar
     float :socket_timeout, default: 30
 
     desc "How long to allow the Kafka brokers to wait before returning messages"
-    float :max_wait_time, default: 5
+    float :max_wait_time, default: 1
 
     desc "A prefix used when generating consumer group names"
     string :group_id_prefix


### PR DESCRIPTION
In https://github.com/zendesk/ruby-kafka/pull/434, the default `max_wait_time` in ruby-kafka was changed to 1 second.

This make the corresponding change for racecar, since the default here overrides the ruby-kafka default.