### PR TITLE
Expose offset_retention_time configuration for consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Change the default `max_wait_time` to 1 second.
+* Allow setting the `offset_retention_time` for consumers.
 
 ## racecar v0.3.7
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The consumers will checkpoint their positions from time to time in order to be a
 
 * `offset_commit_interval` – How often to save the consumer's position in Kafka. Default is every 10 seconds.
 * `offset_commit_threshold` – How many messages to process before forcing a checkpoint. Default is 0, which means there's no limit. Setting this to e.g. 100 makes the consumer stop every 100 messages to checkpoint its position.
+* `offset_retention_time` - How long committed offsets will be retained. Defaults to the broker setting.
 
 #### Timeouts & intervals
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -19,6 +19,9 @@ module Racecar
     desc "How often to send a heartbeat message to Kafka"
     float :heartbeat_interval, default: 10
 
+    desc "How long committed offsets will be retained."
+    integer :offset_retention_time
+
     desc "How long to pause a partition for if the consumer raises an exception while processing a message"
     float :pause_timeout, default: 10
 
@@ -139,6 +142,7 @@ module Racecar
 
       self.subscriptions = consumer_class.subscriptions
       self.max_wait_time = consumer_class.max_wait_time || self.max_wait_time
+      self.offset_retention_time = consumer_class.offset_retention_time || self.offset_retention_time
       self.pidfile ||= "#{group_id}.pid"
     end
 

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -5,6 +5,7 @@ module Racecar
     class << self
       attr_accessor :max_wait_time
       attr_accessor :group_id
+      attr_accessor :offset_retention_time
 
       def subscriptions
         @subscriptions ||= []

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -35,6 +35,7 @@ module Racecar
         offset_commit_threshold: config.offset_commit_threshold,
         session_timeout: config.session_timeout,
         heartbeat_interval: config.heartbeat_interval,
+        offset_retention_time: config.offset_retention_time,
       )
 
       # Stop the consumer on SIGINT, SIGQUIT or SIGTERM.

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -61,6 +61,14 @@ describe Racecar::Config do
       expect(config.group_id).to eq "my-app.do-stuff-consumer"
     end
 
+    it "sets the offset_retention_time if one has been explicitly defined" do
+      consumer_class.offset_retention_time = 86400
+
+      config.load_consumer_class(consumer_class)
+
+      expect(config.offset_retention_time).to eq 86400
+    end
+
     it "sets the subscriptions to the ones defined on the consumer class" do
       consumer_class.subscriptions = ["one", "two"]
 
@@ -72,13 +80,16 @@ describe Racecar::Config do
     it "doesn't override existing values if the consumer hasn't specified anything" do
       consumer_class.max_wait_time = nil
       consumer_class.group_id = nil
+      consumer_class.offset_retention_time = nil
 
       config.max_wait_time = 10
       config.group_id = "cats"
+      config.offset_retention_time = 43200
       config.load_consumer_class(consumer_class)
 
       expect(config.max_wait_time).to eq 10
       expect(config.group_id).to eq "cats"
+      expect(config.offset_retention_time).to eq 43200
     end
   end
 


### PR DESCRIPTION
This change exposes the `offset_retention_time` from the ruby-kafka Consumer API (https://github.com/zendesk/ruby-kafka/pull/316) for Racecar consumers.

The `offset_retention_time` can be set globally or for an individual consumer class.