### PR TITLE
Remove separate "start" instrumentation events

### DIFF
--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -74,10 +74,6 @@ module Racecar
               offset: message.offset,
             }
 
-            # Allow subscribers to receive a notification *before* we process the
-            # message.
-            @instrumenter.instrument("start_process_message.racecar", payload)
-
             @instrumenter.instrument("process_message.racecar", payload) do
               processor.process(message)
               producer.deliver_messages
@@ -92,10 +88,6 @@ module Racecar
               first_offset: batch.first_offset,
               message_count: batch.messages.count,
             }
-
-            # Allow subscribers to receive a notification *before* we process the
-            # message.
-            @instrumenter.instrument("start_process_batch.racecar", payload)
 
             @instrumenter.instrument("process_batch.racecar", payload) do
               processor.process_batch(batch)

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -204,7 +204,6 @@ describe Racecar::Runner do
         topic: "greetings"
       )
 
-      expect(instrumenter).to receive(:instrument).with("start_process_message.racecar", payload)
       expect(instrumenter).to receive(:instrument).with("process_message.racecar", payload)
 
       runner.run
@@ -262,7 +261,6 @@ describe Racecar::Runner do
         topic: "greetings"
       )
 
-      expect(instrumenter).to receive(:instrument).with("start_process_batch.racecar", payload)
       expect(instrumenter).to receive(:instrument).with("process_batch.racecar", payload)
 
       runner.run


### PR DESCRIPTION
These are no longer needed by the Datadog APM integration.