### PR TITLE
Allow configuring the logger on Config

### DIFF
--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -27,11 +27,11 @@ module Racecar
   end
 
   def self.logger
-    @logger ||= Logger.new(STDOUT)
+    config.logger
   end
 
   def self.logger=(logger)
-    @logger = logger
+    config.logger = logger
   end
 
   def self.instrumenter

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -109,12 +109,13 @@ module Racecar
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 
-    attr_accessor :subscriptions
+    attr_accessor :subscriptions, :logger
 
     def initialize(env: ENV)
       super(env: env)
       @error_handler = proc {}
       @subscriptions = []
+      @logger = Logger.new(STDOUT)
     end
 
     def inspect


### PR DESCRIPTION
For example:

```ruby
Racecar.configure do |config|
  config.logger = Logger.new("my.log")
end
```

Fixes #71.