### PR TITLE
Add support for configuring exponential pause backoff

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -25,6 +25,12 @@ module Racecar
     desc "How long to pause a partition for if the consumer raises an exception while processing a message -- set to -1 to pause indefinitely"
     float :pause_timeout, default: 10
 
+    desc "When `pause_timeout` and `pause_with_exponential_backoff` are configured, this sets an upper limit on the pause duration"
+    float :max_pause_timeout, default: nil
+
+    desc "Whether to exponentially increase the pause timeout on successive errors -- the timeout is doubled each time"
+    boolean :pause_with_exponential_backoff, default: false
+
     desc "The idle timeout after which a consumer is kicked out of the group"
     float :session_timeout, default: 30
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -113,7 +113,13 @@ module Racecar
           # The partition is automatically resumed after the specified timeout, and will continue where we
           # left off.
           @logger.warn "Pausing partition #{e.topic}/#{e.partition} for #{config.pause_timeout} seconds"
-          consumer.pause(e.topic, e.partition, timeout: config.pause_timeout)
+          consumer.pause(
+            e.topic,
+            e.partition,
+            timeout: config.pause_timeout,
+            max_timeout: config.max_pause_timeout,
+            exponential_backoff: config.pause_with_exponential_backoff?,
+          )
         elsif config.pause_timeout == -1
           # A pause timeout of -1 means indefinite pausing, which in ruby-kafka is done by passing nil as
           # the timeout.

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -108,7 +108,7 @@ class FakeConsumer
     end
   end
 
-  def pause(topic, partition, timeout:)
+  def pause(topic, partition, timeout:, max_timeout: nil, exponential_backoff: false)
     @kafka.paused_partitions[topic] ||= {}
     @kafka.paused_partitions[topic][partition] = true
   end


### PR DESCRIPTION
If processing a partition raises an exception again after a pause duration has expired, the next pause will be twice as long. This continues until either the max pause timeout is reached, or the processing succeeds.

Fixes #73.