### PR TITLE
Update process title with current status

### DIFF
--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -3,6 +3,7 @@ require "logger"
 require "fileutils"
 require "racecar/rails_config_file_loader"
 require "racecar/daemon"
+require "racecar/procline_subscriber"
 
 module Racecar
   class Cli
@@ -22,6 +23,8 @@ module Racecar
 
     def run
       $stderr.puts "=> Starting Racecar consumer #{consumer_name}..."
+
+      ProclineSubscriber.setup!
 
       RailsConfigFileLoader.load!
 

--- a/lib/racecar/procline_subscriber.rb
+++ b/lib/racecar/procline_subscriber.rb
@@ -1,0 +1,86 @@
+require "active_support/notifications"
+
+module Racecar
+  # Subscribes to ruby-kafka instrumentation events and updates the process' title
+  # to display the consumer status.
+  class ProclineSubscriber
+    PATTERN = /\w+\.consumer\.kafka/
+
+    def self.setup!
+      subscriber = new
+      ActiveSupport::Notifications.subscribe(PATTERN, subscriber)
+    end
+
+    # ActiveSupport 4+ calls this on event start.
+    def start(name, _id, payload)
+      delegate(:start, name, payload)
+    end
+
+    # ActiveSupport 4+ calls this on event finish.
+    def finish(name, _id, payload)
+      delegate(:finish, name, payload)
+    end
+
+    def start_join_group(payload)
+      procline! "joining group"
+    end
+
+    def finish_join_group(payload)
+      exception = payload[:exception]
+
+      if exception.nil?
+        procline! "joined group"
+      else
+        procline! "failed to join group"
+      end
+    end
+
+    def start_sync_group(payload)
+      procline! "syncing group"
+    end
+
+    def finish_sync_group(payload)
+      exception = payload[:exception]
+
+      if exception.nil?
+        procline! "synced group"
+      else
+        procline! "failed to sync group"
+      end
+    end
+
+    def start_leave_group(payload)
+      procline! "leaving group"
+    end
+
+    def finish_leave_group(payload)
+      exception = payload[:exception]
+
+      if exception.nil?
+        procline! "left group"
+      else
+        procline! "error when leaving group"
+      end
+    end
+
+    def start_loop(payload)
+      procline! "processing"
+    end
+
+    def finish_loop(payload)
+      procline! "stopped processing"
+    end
+
+    private
+
+    def delegate(hook, name, payload)
+      event_name = name.split(".").first
+      method_name = "#{hook}_#{event_name}"
+      send(method_name, payload) if respond_to?(method_name)
+    end
+
+    def procline!(status)
+      Process.setproctitle("racecar (#{status})")
+    end
+  end
+end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -10,11 +10,15 @@ module Racecar
     end
 
     def stop
+      procline! "stopping"
+
       processor.teardown
       consumer.stop unless consumer.nil?
     end
 
     def run
+      procline! "starting"
+
       kafka = Kafka.new(
         client_id: config.client_id,
         seed_brokers: config.brokers,
@@ -66,6 +70,8 @@ module Racecar
       processor.configure(producer: producer)
 
       begin
+        procline! "processing"
+
         if processor.respond_to?(:process)
           consumer.each_message(max_wait_time: config.max_wait_time) do |message|
             payload = {
@@ -138,8 +144,16 @@ module Racecar
 
         raise
       else
+        procline! "graceful-shutdown"
+
         @logger.info "Gracefully shutting down"
       end
+    end
+
+    private
+
+    def procline!(status)
+      $0 = "racecar #{processor.class} (#{status})"
     end
   end
 end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -10,15 +10,11 @@ module Racecar
     end
 
     def stop
-      procline! "stopping"
-
       processor.teardown
       consumer.stop unless consumer.nil?
     end
 
     def run
-      procline! "starting"
-
       kafka = Kafka.new(
         client_id: config.client_id,
         seed_brokers: config.brokers,
@@ -70,8 +66,6 @@ module Racecar
       processor.configure(producer: producer)
 
       begin
-        procline! "processing"
-
         if processor.respond_to?(:process)
           consumer.each_message(max_wait_time: config.max_wait_time) do |message|
             payload = {
@@ -144,16 +138,8 @@ module Racecar
 
         raise
       else
-        procline! "graceful-shutdown"
-
         @logger.info "Gracefully shutting down"
       end
-    end
-
-    private
-
-    def procline!(status)
-      $0 = "racecar #{processor.class} (#{status})"
     end
   end
 end

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "activesupport"
 end


### PR DESCRIPTION
Allows operators to understand what a Racecar consumer is currently doing.

The current set of statuses is not sufficient to warrant this feature. I'd have to add support for the following:

- [ ] the number of partitions assigned to the process.
- [ ] whether all processing has been paused.
- [x] the internal status of the consumer, e.g. `running`, `joining`, `syncing`, etc. 