### PR TITLE
Report CLI failures to the registered error handler

### DIFF
--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -64,6 +64,8 @@ module Racecar
     rescue => e
       $stderr.puts "=> Crashed: #{e.class}: #{e}\n#{e.backtrace.join("\n")}"
 
+      config.error_handler.call(e)
+
       raise
     end
 


### PR DESCRIPTION
Currently when the CLI fails in certain situations, for example when there's a misconfiguration that causes the subscription to fail, no error is reported to the error handler.