### PR TITLE
Allow configuring `max_bytes`

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -43,6 +43,9 @@ module Racecar
     desc "How long to allow the Kafka brokers to wait before returning messages"
     float :max_wait_time, default: 1
 
+    desc "The maximum size of message sets returned from a single fetch"
+    integer :max_bytes, default: 10485760
+
     desc "A prefix used when generating consumer group names"
     string :group_id_prefix
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -67,7 +67,7 @@ module Racecar
 
       begin
         if processor.respond_to?(:process)
-          consumer.each_message(max_wait_time: config.max_wait_time) do |message|
+          consumer.each_message(max_wait_time: config.max_wait_time, max_bytes: config.max_bytes) do |message|
             payload = {
               consumer_class: processor.class.to_s,
               topic: message.topic,
@@ -81,7 +81,7 @@ module Racecar
             end
           end
         elsif processor.respond_to?(:process_batch)
-          consumer.each_batch(max_wait_time: config.max_wait_time) do |batch|
+          consumer.each_batch(max_wait_time: config.max_wait_time, max_bytes: config.max_bytes) do |batch|
             payload = {
               consumer_class: processor.class.to_s,
               topic: batch.topic,


### PR DESCRIPTION
The max size of fetch responses. Used to avoid blowing out the memory of consumers.