### PR TITLE
Allow configuring `max_fetch_queue_size`

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -22,6 +22,9 @@ module Racecar
     desc "How long committed offsets will be retained."
     integer :offset_retention_time
 
+    desc "The maximum number of fetch responses to keep queued before processing"
+    integer :max_fetch_queue_size, default: 10
+
     desc "How long to pause a partition for if the consumer raises an exception while processing a message -- set to -1 to pause indefinitely"
     float :pause_timeout, default: 10
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -30,7 +30,7 @@ module Racecar
         sasl_scram_username: config.sasl_scram_username,
         sasl_scram_password: config.sasl_scram_password,
         sasl_scram_mechanism: config.sasl_scram_mechanism,
-        ssl_ca_certs_from_system: config.ssl_ca_certs_from_system
+        ssl_ca_certs_from_system: config.ssl_ca_certs_from_system,
       )
 
       @consumer = kafka.consumer(
@@ -40,6 +40,7 @@ module Racecar
         session_timeout: config.session_timeout,
         heartbeat_interval: config.heartbeat_interval,
         offset_retention_time: config.offset_retention_time,
+        fetcher_max_queue_size: config.max_fetch_queue_size,
       )
 
       # Stop the consumer on SIGINT, SIGQUIT or SIGTERM.


### PR DESCRIPTION
Limits the number of fetch responses to keep queued.