### PR TITLE
allow consumers to set brokers

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -162,6 +162,8 @@ module Racecar
     end
 
     def load_consumer_class(consumer_class)
+      self.brokers = consumer_class.brokers || self.brokers
+
       self.group_id = consumer_class.group_id || self.group_id
 
       self.group_id ||= [

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -6,6 +6,7 @@ module Racecar
       attr_accessor :max_wait_time
       attr_accessor :group_id
       attr_accessor :offset_retention_time
+      attr_accessor :brokers
 
       def subscriptions
         @subscriptions ||= []

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -56,6 +56,14 @@ describe Racecar::Config do
       OpenStruct.new(group_id: nil, name: "DoStuffConsumer", subscriptions: [])
     }
 
+    it "sets the brokers if they have been explicitly defined" do
+      consumer_class.brokers = ["broker1", "broker2"]
+
+      config.load_consumer_class(consumer_class)
+
+      expect(config.brokers).to match_array ["broker1", "broker2"]
+    end
+
     it "sets the group id if one has been explicitly defined" do
       consumer_class.group_id = "fiddle"
 


### PR DESCRIPTION
Let consumers set their own brokers with `self.brokers = ['broker1', 'broker2']`