### PR TITLE
Require ruby-kafka v0.7.0 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Racecar is a friendly and easy-to-approach Kafka consumer framework. It allows y
 
 The framework is based on [ruby-kafka](https://github.com/zendesk/ruby-kafka), which, when used directly, can be a challenge: it's a flexible library with lots of knobs and options. Most users don't need that level of flexibility, though. Racecar provides a simple and intuitive way to build and configure Kafka consumers.
 
-**NOTE:** Racecar requires Kafka 0.10 or higher.
+**NOTE:** Racecar requires Kafka 0.11 or higher.
 
 ## Table of content
 

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "king_konf", "~> 0.3.7"
-  spec.add_runtime_dependency "ruby-kafka", "~> 0.6"
+  spec.add_runtime_dependency "ruby-kafka", "~> 0.7"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Updating to `ruby-kafka ~> 0.7` means that support for Kafka 0.10 is dropped (From https://github.com/zendesk/ruby-kafka/blob/master/CHANGELOG.md#070)

Closes #98 