### PR TITLE
Implement support for manual heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,23 @@ Any headers set on the message will be available when consuming the message:
 message.headers #=> { "Header-A" => 42, ... }
 ```
 
+#### Heartbeats
+
+In order to avoid your consumer being kicked out of its group during long-running message processing operations, it may be a good idea to periodically send so-called _heartbeats_ back to Kafka. This is done automatically for you after each message has been processed, but if the processing of a _single_ message takes a long time you may run into group stability issues.
+
+If possible, intersperse `heartbeat` calls in between long-running operations in your consumer, e.g.
+
+```ruby
+def process(message)
+  long_running_op_one(message)
+
+  # Signals back to Kafka that we're still alive!
+  heartbeat
+
+  long_running_op_two(message)
+end
+```
+
 
 #### Tearing down resources when stopping
 

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -28,13 +28,18 @@ module Racecar
       end
     end
 
-    def configure(producer:)
+    def configure(consumer:, producer:)
+      @_consumer = consumer
       @_producer = producer
     end
 
     def teardown; end
 
     protected
+
+    def heartbeat
+      @_consumer.trigger_heartbeat
+    end
 
     def produce(value, **options)
       @_producer.produce(value, **options)

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -66,7 +66,7 @@ module Racecar
         compression_codec: config.producer_compression_codec,
       )
 
-      processor.configure(producer: producer)
+      processor.configure(consumer: consumer, producer: producer)
 
       begin
         if processor.respond_to?(:process)


### PR DESCRIPTION
Fixes #61.

Right now we only support async heartbeats – let's see if there's a need for a blocking version before adding it in.