### PR TITLE
Allow configuring `sasl_over_ssl`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## racecar v0.5.0
 
 * Add support for manually sending heartbeats with `heartbeat` (#105).
+* Allow configuring `sasl_over_ssl`.
 
 ## racecar v0.4.2
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -100,6 +100,9 @@ module Racecar
     desc "The SCRAM mechanism to use, either `sha256` or `sha512`"
     string :sasl_scram_mechanism, allowed_values: ["sha256", "sha512"]
 
+    desc "Whether to use SASL over SSL."
+    boolean :sasl_over_ssl, default: true
+
     desc "The file in which to store the Racecar process' PID when daemonized"
     string :pidfile
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -32,6 +32,7 @@ module Racecar
         sasl_scram_username: config.sasl_scram_username,
         sasl_scram_password: config.sasl_scram_password,
         sasl_scram_mechanism: config.sasl_scram_mechanism,
+        sasl_over_ssl: config.sasl_over_ssl,
         ssl_ca_certs_from_system: config.ssl_ca_certs_from_system,
       )
 


### PR DESCRIPTION
Would just like be able to use SASL authentication without SSL as my broker doesn't allow this.