### PR TITLE
RSpec: enable zero-monkey patch mode

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,6 +1,6 @@
 require "racecar/cli"
 
-describe Racecar::Cli do
+RSpec.describe Racecar::Cli do
   it "fails if no consumer class is specified" do
     expect { Racecar::Cli.main([]) }.to raise_exception(Racecar::Error, "no consumer specified")
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,7 +1,7 @@
 require "ostruct"
 require "racecar/config"
 
-describe Racecar::Config do
+RSpec.describe Racecar::Config do
   let(:config) { Racecar::Config.new }
 
   it "uses the default config if no explicit value has been set" do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -167,7 +167,7 @@ end
 
 FakeInstrumenter = Class.new(Racecar::NullInstrumenter)
 
-describe Racecar::Runner do
+RSpec.describe Racecar::Runner do
   let(:config) { Racecar::Config.new }
   let(:logger) { Logger.new(StringIO.new) }
   let(:kafka) { FakeKafka.new }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "racecar"
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+end


### PR DESCRIPTION
This PR configures RSpec to use less monkey-patching (none of which was in use in this project, so few changes here).


> Use the `disable_monkey_patching!` configuration option to
> disable all monkey patching done by RSpec:
> 
>  -   stops exposing DSL globally
>   -  disables should and should_not syntax for rspec-expectations
>   -  disables stub, should_receive, and should_not_receive syntax for rspec-mocks
> 

See https://relishapp.com/rspec/rspec-core/v/3-8/docs/configuration/zero-monkey-patching-mode