### PR TITLE
Update version to v0.5.0.beta2

### DIFF
--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,3 +1,3 @@
 module Racecar
-  VERSION = "0.5.0.beta1"
+  VERSION = "0.5.0.beta2"
 end


### PR DESCRIPTION
Update version to `v0.5.0.beta2` for release.

#### Risks
Low.