### PR TITLE
support for ssl_verify_hostname in the configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 /spec/reports/
 /tmp/
 /vendor/bundle/
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /vendor/bundle/
+.idea/

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -26,7 +26,7 @@ module Racecar
       RailsConfigFileLoader.load!
 
       if File.exist?("config/racecar.rb")
-        require "config/racecar"
+        require "racecar/config"
       end
 
       # Find the consumer class by name.

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -26,7 +26,7 @@ module Racecar
       RailsConfigFileLoader.load!
 
       if File.exist?("config/racecar.rb")
-        require "racecar/config"
+        require "./config/racecar"
       end
 
       # Find the consumer class by name.

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -127,6 +127,9 @@ module Racecar
     desc "Tags that should always be set on Datadog metrics"
     list :datadog_tags
 
+    desc "Whether to check the server certificate is valid for the hostname"
+    boolean :ssl_verify_hostname, default: true
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -34,6 +34,7 @@ module Racecar
         sasl_scram_mechanism: config.sasl_scram_mechanism,
         sasl_over_ssl: config.sasl_over_ssl,
         ssl_ca_certs_from_system: config.ssl_ca_certs_from_system,
+        ssl_verify_hostname: config.ssl_verify_hostname
       )
 
       @consumer = kafka.consumer(

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,3 +1,3 @@
 module Racecar
-  VERSION = "0.5.0.beta2"
+  VERSION = "0.5.1.beta2"
 end

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,3 +1,3 @@
 module Racecar
-  VERSION = "0.5.1.beta2"
+  VERSION = "0.5.2.beta2"
 end

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,3 +1,3 @@
 module Racecar
-  VERSION = "0.5.3.beta2"
+  VERSION = "0.5.4.beta2"
 end

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,3 +1,3 @@
 module Racecar
-  VERSION = "0.5.4.beta2"
+  VERSION = "0.5.0.beta2"
 end

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,3 +1,3 @@
 module Racecar
-  VERSION = "0.5.2.beta2"
+  VERSION = "0.5.3.beta2"
 end

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "king_konf", "~> 0.3.7"
-  spec.add_runtime_dependency "ruby-kafka", "~> 0.6"
+  spec.add_runtime_dependency "ruby-kafka", "~> 0.7.8"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
ruby-kafka introduce new configuration property that solve a critical issue when connecting to Heroku with SSL: [SSL verification breaks Heroku Kafka #734](https://github.com/zendesk/ruby-kafka/issues/734)
Without this fix I wasn't able to connect to heroku's Kafka with racecar...