### PR TITLE
Add Docker based integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,19 @@
+name: Run Integration Tests
+
+on: [push]
+
+jobs:
+
+  integration:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build Docker image
+      run: docker build --tag racecar .
+    - name: Start docker-compose services
+      run: docker-compose up --build -d
+    - name: Run test consumer
+      run: |
+        docker run --network container:kafka racecar bundle exec racecarctl produce --value 123 --topic test-tokens

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.6
+WORKDIR /usr/src/app
+
+COPY Gemfile racecar.gemspec ./
+COPY lib/racecar/version.rb ./lib/racecar/version.rb
+
+RUN bundle install
+
+COPY . ./
+
+RUN bundle install
+
+CMD bundle exec racecar --require examples/test_consumer TestConsumer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,12 @@ services:
   racecar:
     container_name: racecar
     build: .
+    volumes:
+      test-results:/test-results
     environment:
       RACECAR_BROKERS: kafka:9092
       RACECAR_LOG_LEVEL: debug
+      RESULTS_DIR: /test-results
 
   zookeeper:
     image: confluentinc/cp-zookeeper:5.3.0
@@ -40,3 +43,6 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
       CONFLUENT_METRICS_ENABLE: 'true'
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
+
+volumes:
+  test-results:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+---
+version: '2'
+services:
+  racecar:
+    container_name: racecar
+    build: .
+    environment:
+      RACECAR_BROKERS: kafka:9092
+      RACECAR_LOG_LEVEL: debug
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.3.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-enterprise-kafka:5.3.0
+    hostname: kafka
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "29092:29092"
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: kafka:29092
+      CONFLUENT_METRICS_REPORTER_ZOOKEEPER_CONNECT: zookeeper:2181
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+      CONFLUENT_METRICS_ENABLE: 'true'
+      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,9 @@ services:
   racecar:
     container_name: racecar
     build: .
-    volumes:
-      test-results:/test-results
     environment:
       RACECAR_BROKERS: kafka:9092
       RACECAR_LOG_LEVEL: debug
-      RESULTS_DIR: /test-results
 
   zookeeper:
     image: confluentinc/cp-zookeeper:5.3.0
@@ -43,6 +40,3 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
       CONFLUENT_METRICS_ENABLE: 'true'
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
-
-volumes:
-  test-results:

--- a/examples/test_consumer.rb
+++ b/examples/test_consumer.rb
@@ -3,17 +3,16 @@ class TestConsumer < Racecar::Consumer
 
   def initialize
     @logger = Logger.new(STDOUT)
-    @base_dir = ENV.fetch("RESULTS_DIR", "/")
+    @token_path = "/token"
   end
 
   def process(message)
     token = message.payload
-    token_path = [@base_dir, token].join("/")
 
     @logger.info "Got #{token}"
 
     File.open(token_path, "w") do |file|
-      file << "OK"
+      file << token
     end
   end
 end

--- a/examples/test_consumer.rb
+++ b/examples/test_consumer.rb
@@ -1,0 +1,19 @@
+class TestConsumer < Racecar::Consumer
+  subscribes_to "test-tokens"
+
+  def initialize
+    @logger = Logger.new(STDOUT)
+    @base_dir = ENV.fetch("RESULTS_DIR", "/")
+  end
+
+  def process(message)
+    token = message.payload
+    token_path = [@base_dir, token].join("/")
+
+    @logger.info "Got #{token}"
+
+    File.open(token_path, "w") do |file|
+      file << "OK"
+    end
+  end
+end

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/zendesk/racecar"
   spec.license       = "Apache License Version 2.0"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+  spec.files         = Dir.glob("**/*").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = "exe"


### PR DESCRIPTION
Work in progress.

The idea is to produce a unique token to a topic, then have the test consumer read that and store it on disk somewhere where we can compare it to the original. That should do for a simple end-to-end test.