### PR TITLE
retry transport failures instead of crashing (can happen during broker shutdown)

### DIFF
--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -15,13 +15,14 @@ module Racecar
       retried ||= false
       msg = current.poll(timeout_ms)
     rescue Rdkafka::RdkafkaError => e
+      raise if retried
+      retried = true
+
       @logger.error "Error for topic subscription #{current_subscription}: #{e}"
 
       case e.code
-      when :max_poll_exceeded
+      when :max_poll_exceeded, :transport # -147, -195
         reset_current_consumer
-        raise if retried
-        retried = true
         retry
       else
         raise


### PR DESCRIPTION
This has been discussed in #122, although that bug is about another issue. 

In my local tests an exponential back off was not needed, since this error is apparently only triggered once when the connection is torn down. 