### PR TITLE
Wrap the rdkafka message

### DIFF
--- a/lib/racecar/message.rb
+++ b/lib/racecar/message.rb
@@ -1,0 +1,21 @@
+require "forwardable"
+
+module Racecar
+  class Message
+    extend Forwardable
+
+    def initialize(rdkafka_message)
+      @rdkafka_message = rdkafka_message
+    end
+
+    def_delegators :@rdkafka_message, :topic, :partition, :offset, :key, :value, :headers
+
+    def create_time
+      @rdkafka_message.timestamp
+    end
+
+    def ==(other)
+      @rdkafka_message == other.instance_variable_get(:@rdkafka_message)
+    end
+  end
+end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -439,8 +439,8 @@ RSpec.describe Racecar::Runner do
         topic: "greetings"
       )
 
-      expect(processor).to receive(:process_batch).with([kafka.received_messages["greetings"][0]])
-      expect(processor).to receive(:process_batch).with(kafka.received_messages["greetings"][1, 2])
+      expect(processor).to receive(:process_batch).with([Racecar::Message.new(kafka.received_messages["greetings"][0])])
+      expect(processor).to receive(:process_batch).with(kafka.received_messages["greetings"][1, 2].map {|message| Racecar::Message.new(message) })
 
       runner.run
     end


### PR DESCRIPTION
Provides backwards compatibility and avoids leaking internals.