### PR TITLE
retry poll failures with exponential backoff (see #122)

### DIFF
--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -24,7 +24,7 @@ module Racecar
       try += 1
       raise if try >= MAX_POLL_TRIES || remain <= wait_before_retry_ms
 
-      @logger.error "(try #{try} of #{MAX_POLL_TRIES}): Error for topic subscription #{current_subscription}: #{e}"
+      @logger.error "(try #{try}): Error for topic subscription #{current_subscription}: #{e}"
 
       case e.code
       when :max_poll_exceeded, :transport # -147, -195


### PR DESCRIPTION
As per https://github.com/zendesk/racecar/issues/122#issuecomment-530777250 , let's keep to the existing promises. 

It doesn't fix the specific issue mentioned in #122, though.