### PR TITLE
Add Option To Not Boot Rails When Starting Consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ Racecar supports configuring ruby-kafka's [Datadog](https://www.datadoghq.com/) 
 * `datadog_namespace` – The namespace to use for Datadog metrics.
 * `datadog_tags` – Tags that should always be set on Datadog metrics.
 
+#### Consumers Without Rails ####
+
+By default, if Rails is detected, it will be automatically started when the consumer is started. There are cases where you might not want or need Rails. You can pass the `--without-rails` option when starting the consumer and Rails won't be started.
 
 ### Testing consumers
 

--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -18,6 +18,10 @@ module Racecar
     @config ||= Config.new
   end
 
+  def self.config=(config)
+    @config = config
+  end
+
   def self.configure
     yield config
   end

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -23,7 +23,7 @@ module Racecar
     def run
       $stderr.puts "=> Starting Racecar consumer #{consumer_name}..."
 
-      RailsConfigFileLoader.load! unless config.disable_rails?
+      RailsConfigFileLoader.load! unless config.without_rails?
 
       if File.exist?("config/racecar.rb")
         require "./config/racecar"

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -23,7 +23,7 @@ module Racecar
     def run
       $stderr.puts "=> Starting Racecar consumer #{consumer_name}..."
 
-      RailsConfigFileLoader.load!
+      RailsConfigFileLoader.load! unless config.norails
 
       if File.exist?("config/racecar.rb")
         require "./config/racecar"

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -23,7 +23,7 @@ module Racecar
     def run
       $stderr.puts "=> Starting Racecar consumer #{consumer_name}..."
 
-      RailsConfigFileLoader.load! unless config.norails?
+      RailsConfigFileLoader.load! unless config.disable_rails?
 
       if File.exist?("config/racecar.rb")
         require "./config/racecar"

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -23,7 +23,7 @@ module Racecar
     def run
       $stderr.puts "=> Starting Racecar consumer #{consumer_name}..."
 
-      RailsConfigFileLoader.load! unless config.norails
+      RailsConfigFileLoader.load! unless config.norails?
 
       if File.exist?("config/racecar.rb")
         require "./config/racecar"

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -137,7 +137,7 @@ module Racecar
     boolean :ssl_verify_hostname, default: true
 
     desc "Whether to boot Rails when starting the consumer"
-    boolean :disable_rails, default: false
+    boolean :without_rails, default: false
 
     # The error handler must be set directly on the object.
     attr_reader :error_handler

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -137,7 +137,7 @@ module Racecar
     boolean :ssl_verify_hostname, default: true
 
     desc "Whether to boot Rails when starting the consumer"
-    boolean :norails, default: false
+    boolean :disable_rails, default: false
 
     # The error handler must be set directly on the object.
     attr_reader :error_handler

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -136,6 +136,9 @@ module Racecar
     desc "Whether to check the server certificate is valid for the hostname"
     boolean :ssl_verify_hostname, default: true
 
+    desc "Whether to boot Rails when starting the consumer"
+    boolean :norails, default: false
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Racecar::Cli do
     expect { Racecar::Cli.main([]) }.to raise_exception(Racecar::Error, "no consumer specified")
   end
 
-  it "doesn't start Rails if --norrails option is specified" do
-    args = ["--require", "./examples/cat_consumer.rb", "CatConsumer", "--norails"]
+  it "doesn't start Rails if --disable-rails option is specified" do
+    args = ["--require", "./examples/cat_consumer.rb", "CatConsumer", "--disable-rails"]
 
     allow(Racecar).to receive(:run)
     expect(Racecar::RailsConfigFileLoader).not_to receive(:load!)
@@ -19,7 +19,7 @@ RSpec.describe Racecar::Cli do
     Racecar::Cli.main(args)
   end
 
-  it "starts Rails if the --norails option is omitted" do
+  it "starts Rails if the --disable-rails option is omitted" do
     args = ["--require", "./examples/cat_consumer.rb", "CatConsumer"]
 
     allow(Racecar).to receive(:run)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,7 +1,30 @@
 require "racecar/cli"
 
 RSpec.describe Racecar::Cli do
+  # has to be reset between examples otherwise it caches across examples and causes unexpected behavior
+  before do
+    Racecar.config = nil
+  end
+
   it "fails if no consumer class is specified" do
     expect { Racecar::Cli.main([]) }.to raise_exception(Racecar::Error, "no consumer specified")
+  end
+
+  it "doesn't start Rails if --no-rails option is specified" do
+    args = ["--require", "./examples/cat_consumer.rb", "CatConsumer", "--norails"]
+
+    allow(Racecar).to receive(:run)
+    expect(Racecar::RailsConfigFileLoader).not_to receive(:load!)
+
+    Racecar::Cli.main(args)
+  end
+
+  it "starts Rails if the --no-rails option is omitted" do
+    args = ["--require", "./examples/cat_consumer.rb", "CatConsumer"]
+
+    allow(Racecar).to receive(:run)
+    expect(Racecar::RailsConfigFileLoader).to receive(:load!)
+
+    Racecar::Cli.main(args)
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Racecar::Cli do
     expect { Racecar::Cli.main([]) }.to raise_exception(Racecar::Error, "no consumer specified")
   end
 
-  it "doesn't start Rails if --no-rails option is specified" do
+  it "doesn't start Rails if --norrails option is specified" do
     args = ["--require", "./examples/cat_consumer.rb", "CatConsumer", "--norails"]
 
     allow(Racecar).to receive(:run)
@@ -19,7 +19,7 @@ RSpec.describe Racecar::Cli do
     Racecar::Cli.main(args)
   end
 
-  it "starts Rails if the --no-rails option is omitted" do
+  it "starts Rails if the --norails option is omitted" do
     args = ["--require", "./examples/cat_consumer.rb", "CatConsumer"]
 
     allow(Racecar).to receive(:run)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Racecar::Cli do
     expect { Racecar::Cli.main([]) }.to raise_exception(Racecar::Error, "no consumer specified")
   end
 
-  it "doesn't start Rails if --disable-rails option is specified" do
-    args = ["--require", "./examples/cat_consumer.rb", "CatConsumer", "--disable-rails"]
+  it "doesn't start Rails if --without-rails option is specified" do
+    args = ["--require", "./examples/cat_consumer.rb", "CatConsumer", "--without-rails"]
 
     allow(Racecar).to receive(:run)
     expect(Racecar::RailsConfigFileLoader).not_to receive(:load!)
@@ -19,7 +19,7 @@ RSpec.describe Racecar::Cli do
     Racecar::Cli.main(args)
   end
 
-  it "starts Rails if the --disable-rails option is omitted" do
+  it "starts Rails if the --without-rails option is omitted" do
     args = ["--require", "./examples/cat_consumer.rb", "CatConsumer"]
 
     allow(Racecar).to receive(:run)


### PR DESCRIPTION
In the case of simple consumers, there would be no need to boot Rails to process the messages, as you wouldn't necessarily need Rails. This is particularly advantageous in larger Rails applications, which would use significantly more resources than a simple consumer running vanilla Ruby.

I benchmarked the consumer we use at the company I work for - both with and without starting Rails. With Rails it uses 282M whereas without it uses 23M, just under a 92% saving in terms of memory alone.

