### PR TITLE
Datadog instrumentation

### DIFF
--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -144,13 +144,14 @@ module Racecar
     end
 
     def configure_datadog
-      require "kafka/datadog"
+      require_relative './datadog'
 
-      datadog = Kafka::Datadog
-      datadog.host = config.datadog_host unless config.datadog_host.nil?
-      datadog.port = config.datadog_port unless config.datadog_port.nil?
-      datadog.namespace = config.datadog_namespace unless config.datadog_namespace.nil?
-      datadog.tags = config.datadog_tags unless config.datadog_tags.nil?
+      Datadog.configure do |datadog|
+        datadog.host      = config.datadog_host unless config.datadog_host.nil?
+        datadog.port      = config.datadog_port unless config.datadog_port.nil?
+        datadog.namespace = config.datadog_namespace unless config.datadog_namespace.nil?
+        datadog.tags      = config.datadog_tags unless config.datadog_tags.nil?
+      end
     end
   end
 end

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -1,0 +1,245 @@
+begin
+  require "datadog/statsd"
+rescue LoadError
+  $stderr.puts "In order to report Kafka client metrics to Datadog you need to install the `dogstatsd-ruby` gem."
+  raise
+end
+
+require "active_support/subscriber"
+
+module Racecar
+  module Datadog
+    STATSD_NAMESPACE = "racecar"
+
+    class << self
+      def configure
+        yield self
+      end
+
+      def statsd
+        @statsd ||= ::Datadog::Statsd.new(host, port, namespace: namespace, tags: tags)
+      end
+
+      def statsd=(statsd)
+        clear
+        @statsd = statsd
+      end
+
+      def host
+        @host ||= default_host
+      end
+
+      def host=(host)
+        @host = host
+        clear
+      end
+
+      def port
+        @port ||= default_port
+      end
+
+      def port=(port)
+        @port = port
+        clear
+      end
+
+      def namespace
+        @namespace ||= STATSD_NAMESPACE
+      end
+
+      def namespace=(namespace)
+        @namespace = namespace
+        clear
+      end
+
+      def tags
+        @tags ||= []
+      end
+
+      def tags=(tags)
+        @tags = tags
+        clear
+      end
+
+      private
+
+      def default_host
+        if ::Datadog::Statsd.const_defined?(:Connection)
+          ::Datadog::Statsd::Connection::DEFAULT_HOST
+        else
+          ::Datadog::Statsd::DEFAULT_HOST
+        end
+      end
+
+      def default_port
+        if ::Datadog::Statsd.const_defined?(:Connection)
+          ::Datadog::Statsd::Connection::DEFAULT_PORT
+        else
+          ::Datadog::Statsd::DEFAULT_PORT
+        end
+      end
+
+      def clear
+        @statsd && @statsd.close
+        @statsd = nil
+      end
+    end
+
+    class StatsdSubscriber < ActiveSupport::Subscriber
+      private
+
+      %w[increment histogram count timing gauge].each do |type|
+        define_method(type) do |*args|
+          emit(type, *args)
+        end
+      end
+
+      def emit(type, *args, tags: {})
+        tags = tags.map {|k, v| "#{k}:#{v}" }.to_a
+
+        Racecar::Datadog.statsd.send(type, *args, tags: tags)
+      end
+    end
+
+    class ConsumerSubscriber < StatsdSubscriber
+      def process_message(event)
+        offset = event.payload.fetch(:offset)
+        create_time = event.payload.fetch(:create_time)
+        time_lag = create_time && ((Time.now - create_time) * 1000).to_i
+        tags = default_tags(event)
+
+        if event.payload.key?(:exception)
+          increment("consumer.process_message.errors", tags: tags)
+        else
+          timing("consumer.process_message.latency", event.duration, tags: tags)
+          increment("consumer.messages", tags: tags)
+        end
+
+        gauge("consumer.offset", offset, tags: tags)
+
+        # Not all messages have timestamps.
+        if time_lag
+          gauge("consumer.time_lag", time_lag, tags: tags)
+        end
+      end
+
+      def process_batch(event)
+        offset = event.payload.fetch(:last_offset)
+        messages = event.payload.fetch(:message_count)
+        tags = default_tags(event)
+
+        if event.payload.key?(:exception)
+          increment("consumer.process_batch.errors", tags: tags)
+        else
+          timing("consumer.process_batch.latency", event.duration, tags: tags)
+          count("consumer.messages", messages, tags: tags)
+        end
+
+        gauge("consumer.offset", offset, tags: tags)
+      end
+
+      def join_group(event)
+        tags = {
+          client: event.payload.fetch(:client_id),
+          group_id: event.payload.fetch(:group_id),
+        }
+
+        timing("consumer.join_group", event.duration, tags: tags)
+
+        if event.payload.key?(:exception)
+          increment("consumer.join_group.errors", tags: tags)
+        end
+      end
+
+      def leave_group(event)
+        tags = {
+          client: event.payload.fetch(:client_id),
+          group_id: event.payload.fetch(:group_id),
+        }
+
+        timing("consumer.leave_group", event.duration, tags: tags)
+
+        if event.payload.key?(:exception)
+          increment("consumer.leave_group.errors", tags: tags)
+        end
+      end
+
+      def main_loop(event)
+        tags = {
+          client: event.payload.fetch(:client_id),
+          group_id: event.payload.fetch(:group_id),
+        }
+
+        histogram("consumer.loop.duration", event.duration, tags: tags)
+      end
+
+      def pause_status(event)
+        duration = event.payload.fetch(:duration)
+
+        gauge("consumer.pause.duration", duration, tags: default_tags(event))
+      end
+
+      private
+
+      def default_tags(event)
+        {
+          client: event.payload.fetch(:client_id),
+          group_id: event.payload.fetch(:group_id),
+          topic: event.payload.fetch(:topic),
+          partition: event.payload.fetch(:partition),
+        }
+      end
+
+      attach_to "racecar"
+    end
+
+    class ProducerSubscriber < StatsdSubscriber
+      def produce_message(event)
+        client = event.payload.fetch(:client_id)
+        topic = event.payload.fetch(:topic)
+        message_size = event.payload.fetch(:message_size)
+        buffer_size = event.payload.fetch(:buffer_size)
+
+        tags = {
+          client: client,
+          topic: topic,
+        }
+
+        # This gets us the write rate.
+        increment("producer.produce.messages", tags: tags.merge(topic: topic))
+
+        # Information about typical/average/95p message size.
+        histogram("producer.produce.message_size", message_size, tags: tags.merge(topic: topic))
+
+        # Aggregate message size.
+        count("producer.produce.message_size.sum", message_size, tags: tags.merge(topic: topic))
+
+        # This gets us the avg/max buffer size per producer.
+        histogram("producer.buffer.size", buffer_size, tags: tags)
+      end
+
+      def deliver_messages(event)
+        client = event.payload.fetch(:client_id)
+        message_count = event.payload.fetch(:delivered_message_count)
+
+        tags = {
+          client: client,
+        }
+
+        timing("producer.deliver.latency", event.duration, tags: tags)
+
+        # Messages delivered to Kafka:
+        count("producer.deliver.messages", message_count, tags: tags)
+      end
+
+      def acknowledged_message(event)
+        tags = { client: event.payload.fetch(:client_id) }
+
+        # Number of messages ACK'd for the topic.
+        increment("producer.ack.messages", tags: tags)
+      end
+
+      attach_to "producer.racecar"
+    end
+  end
+end

--- a/lib/racecar/instrumenter.rb
+++ b/lib/racecar/instrumenter.rb
@@ -1,0 +1,24 @@
+module Racecar
+  ##
+  # Common API for instrumentation to standardize
+  # namespace and default payload
+  #
+  class Instrumenter
+    NAMESPACE = "racecar"
+    attr_reader :backend
+
+    def initialize(default_payload = {})
+      @default_payload = default_payload
+
+      @backend = if defined?(ActiveSupport::Notifications)
+        ActiveSupport::Notifications
+      else
+        NullInstrumenter
+      end
+    end
+
+    def instrument(event_name, payload = {}, &block)
+      @backend.instrument("#{event_name}.#{NAMESPACE}", @default_payload.merge(payload), &block)
+    end
+  end
+end

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "timecop"
+  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 5.0.0"
+  spec.add_development_dependency "activesupport", ">= 4.0", "< 6.1"
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe Racecar::Config do
     end
 
     it "sets the client id from RACECAR_CLIENT_ID" do
-      ENV["RACECAR_CLIENT_ID"] = "witch"
-
-      expect(config.client_id).to eq "witch"
+      with_env('RACECAR_CLIENT_ID', 'witch') do
+        expect(config.client_id).to eq "witch"
+      end
     end
 
     it "sets the offset commit interval from RACECAR_OFFSET_COMMIT_INTERVAL" do

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -1,0 +1,358 @@
+require "racecar/datadog"
+RSpec.describe Racecar::Datadog::StatsdSubscriber do
+  describe '#emit' do
+    let(:subscriber)  { Racecar::Datadog::StatsdSubscriber.new }
+    let(:tags)        { { tag_1: 'race', tag_2: 'car'} }
+
+    it 'publishes stats with tags' do
+      expect(Racecar::Datadog.statsd).
+        to receive(:increment).
+        with('metric', tags: ['tag_1:race', 'tag_2:car'])
+
+      subscriber.send(:emit, :increment, 'metric', tags: tags)
+    end
+  end
+end
+
+def create_event(name, payload = {})
+  Timecop.freeze do
+    start = Time.now - 2
+    ending = Time.now - 1
+
+    transaction_id = nil
+
+    args = [name, start, ending, transaction_id, payload]
+
+    ActiveSupport::Notifications::Event.new(*args)
+  end
+end
+
+RSpec.describe Racecar::Datadog::ConsumerSubscriber do
+  before do
+    %w[increment histogram count timing gauge].each do |type|
+      allow(statsd).to receive(type)
+    end
+  end
+  let(:subscriber)  { Racecar::Datadog::ConsumerSubscriber.new }
+  let(:statsd)      { Racecar::Datadog.statsd }
+
+  describe '#process_message' do
+    let(:event) do
+      create_event(
+        'process_message',
+        client_id:      'racecar',
+        group_id:       'test_group',
+        consumer_class: 'TestConsumer',
+        topic:          'test_topic',
+        partition:      1,
+        offset:         2,
+        create_time:    Time.now - 1,
+        key:            'key',
+        value:          'nothing new',
+        headers:        {}
+      )
+    end
+    let(:duration) { 1000.0 }
+    let(:metric_tags) do
+      %w[
+          client:racecar
+          group_id:test_group
+          topic:test_topic
+          partition:1
+        ]
+    end
+
+    it 'publishes latency' do
+      expect(statsd).
+        to receive(:timing).
+        with('consumer.process_message.latency', duration, tags: metric_tags)
+
+      subscriber.process_message(event)
+    end
+
+    it 'gauges offset' do
+      expect(statsd).
+        to receive(:gauge).
+        with('consumer.offset', 2, tags: metric_tags)
+
+      subscriber.process_message(event)
+    end
+
+    it 'gauges time lag' do
+      expect(statsd).
+        to receive(:gauge).
+        with('consumer.time_lag', 1000, tags: metric_tags)
+
+      subscriber.process_message(event)
+    end
+  end
+
+  describe '#process_batch' do
+    let(:event) do
+      create_event(
+        'process_batch',
+        client_id:      'racecar',
+        group_id:       'test_group',
+        consumer_class: 'TestConsumer',
+        topic:          'test_topic',
+        partition:      1,
+        first_offset:   3,
+        last_offset:    10,
+        message_count:  20,
+      )
+    end
+    let(:duration) { 1000.0 }
+    let(:metric_tags) do
+      %w[
+          client:racecar
+          group_id:test_group
+          topic:test_topic
+          partition:1
+        ]
+    end
+
+    it 'publishes latency' do
+      expect(statsd).
+        to receive(:timing).
+        with('consumer.process_batch.latency', duration, tags: metric_tags)
+
+      subscriber.process_batch(event)
+    end
+
+    it 'publishes batch count' do
+      expect(statsd).
+        to receive(:count).
+        with('consumer.messages', 20, tags: metric_tags)
+
+      subscriber.process_batch(event)
+    end
+
+    it 'gauges offset' do
+      expect(statsd).
+        to receive(:gauge).
+        with('consumer.offset', 10, tags: metric_tags)
+
+      subscriber.process_batch(event)
+    end
+  end
+
+  describe '#join_group' do
+    let(:event) do
+      create_event(
+        'join_group',
+        client_id:      'racecar',
+        group_id:       'test_group',
+      )
+    end
+    let(:duration) { 1000.0 }
+    let(:metric_tags) do
+      %w[
+          client:racecar
+          group_id:test_group
+        ]
+    end
+
+    it 'publishes latency' do
+      expect(statsd).
+        to receive(:timing).
+        with('consumer.join_group', duration, tags: metric_tags)
+
+      subscriber.join_group(event)
+    end
+  end
+
+  describe '#leave_group' do
+    let(:event) do
+      create_event(
+        'leave_group',
+        client_id:      'racecar',
+        group_id:       'test_group',
+      )
+    end
+    let(:duration) { 1000.0 }
+    let(:metric_tags) do
+      %w[
+          client:racecar
+          group_id:test_group
+        ]
+    end
+
+    it 'publishes latency' do
+      expect(statsd).
+        to receive(:timing).
+        with('consumer.leave_group', duration, tags: metric_tags)
+
+      subscriber.leave_group(event)
+    end
+  end
+
+  describe '#main_loop' do
+    let(:event) do
+      create_event(
+        'main_loop',
+        client_id:      'racecar',
+        group_id:       'test_group',
+      )
+    end
+    let(:duration) { 1000.0 }
+    let(:metric_tags) do
+      %w[
+          client:racecar
+          group_id:test_group
+        ]
+    end
+
+    it 'publishes loop duration' do
+      expect(statsd).
+        to receive(:histogram).
+        with('consumer.loop.duration', duration, tags: metric_tags)
+
+      subscriber.main_loop(event)
+    end
+  end
+
+  describe '#pause_status' do
+    let(:event) do
+      create_event(
+        'main_loop',
+        client_id: 'racecar',
+        group_id:  'test_group',
+        topic:     'test_topic',
+        partition: 1,
+        duration:  10,
+      )
+    end
+    let(:metric_tags) do
+      %w[
+          client:racecar
+          group_id:test_group
+          topic:test_topic
+          partition:1
+        ]
+    end
+
+    it 'gauges pause duration' do
+      expect(statsd).
+        to receive(:gauge).
+        with('consumer.pause.duration', 10, tags: metric_tags)
+
+      subscriber.pause_status(event)
+    end
+  end
+end
+
+RSpec.describe Racecar::Datadog::ProducerSubscriber do
+  before do
+    %w[increment histogram count timing gauge].each do |type|
+      allow(statsd).to receive(type)
+    end
+  end
+  let(:subscriber)  { Racecar::Datadog::ProducerSubscriber.new }
+  let(:statsd)      { Racecar::Datadog.statsd }
+
+  describe '#produce_message' do
+    let(:event) do
+      create_event(
+        'produce_message',
+        client_id:      'racecar',
+        group_id:       'test_group',
+        topic:          'test_topic',
+        message_size:   12,
+        buffer_size:    10
+      )
+    end
+    let(:metric_tags) do
+      %w[
+          client:racecar
+          topic:test_topic
+        ]
+    end
+
+    it 'increments number of produced messages' do
+      expect(statsd).
+        to receive(:increment).
+        with('producer.produce.messages', tags: metric_tags)
+
+      subscriber.produce_message(event)
+    end
+
+    it 'publishes message size' do
+      expect(statsd).
+        to receive(:histogram).
+        with('producer.produce.message_size', 12, tags: metric_tags)
+
+      subscriber.produce_message(event)
+    end
+
+    it 'aggregates message size' do
+      expect(statsd).
+        to receive(:count).
+        with('producer.produce.message_size.sum', 12, tags: metric_tags)
+
+      subscriber.produce_message(event)
+    end
+
+    it 'publishes buffer size' do
+      expect(statsd).
+        to receive(:histogram).
+        with('producer.buffer.size', 10, tags: metric_tags)
+
+      subscriber.produce_message(event)
+    end
+  end
+
+  describe '#deliver_messages' do
+    let(:event) do
+      create_event(
+        'deliver_messages',
+        client_id:      'racecar',
+        delivered_message_count: 10
+      )
+    end
+    let(:duration) { 1000.0 }
+    let(:metric_tags) do
+      %w[
+          client:racecar
+        ]
+    end
+
+    it 'publishes delivery latency' do
+      expect(statsd).
+        to receive(:timing).
+        with('producer.deliver.latency', duration, tags: metric_tags)
+
+      subscriber.deliver_messages(event)
+    end
+
+    it 'publishes message size' do
+      expect(statsd).
+        to receive(:count).
+        with('producer.deliver.messages', 10, tags: metric_tags)
+
+      subscriber.deliver_messages(event)
+    end
+  end
+
+  describe '#acknowledged_message' do
+    let(:event) do
+      create_event(
+        'deliver_messages',
+        client_id: 'racecar',
+        delivered_message_count: 10
+      )
+    end
+    let(:metric_tags) do
+      %w[
+          client:racecar
+        ]
+    end
+
+    it 'publishes number of acknowledged messages' do
+      expect(statsd).
+        to receive(:increment).
+        with('producer.ack.messages', tags: metric_tags)
+
+      subscriber.acknowledged_message(event)
+    end
+  end
+end

--- a/spec/instrumenter_spec.rb
+++ b/spec/instrumenter_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Racecar::Instrumenter do
+  describe '#instrument' do
+    let(:instrumenter) { Racecar::Instrumenter.new }
+
+    it 'applies a namespace' do
+      expect(instrumenter.backend).
+        to receive(:instrument).
+        with('event.racecar', any_args)
+
+      instrumenter.instrument('event')
+    end
+
+    it 'appends a default payload' do
+      expect(instrumenter.backend).
+        to receive(:instrument).
+        with('event.racecar', client_id: 'race')
+
+      instrumenter.instrument('event', client_id: 'race')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "racecar"
 require "timecop"
+require_relative 'support/mock_env'
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+  config.include MockEnv
 end

--- a/spec/support/mock_env.rb
+++ b/spec/support/mock_env.rb
@@ -1,0 +1,8 @@
+module MockEnv
+  def with_env(env_name, value)
+    initial_state = ENV[env_name]
+    ENV[env_name] = value.to_s
+    yield
+    ENV[env_name] = initial_state
+  end
+end


### PR DESCRIPTION
Moves over `ruby-kafka` instrumentation to Racecar. There are still a lot of metrics missing from the original. I could only address what's currently exposed by `rdkafka`.
It's mostly copy/paste with a few tweaks.

Some notes for review:
* `racecar.consumer.loop.duration` is really noisy. I haven't tested how it was before, but worth taking a look.
* I'm not sure whether we should use `buffer_size:  @delivery_handles.size`. This is the local buffer and not the one from librdkafka. Hoping for some ideas.
* `join_group` and `leave_group` instrumentation might be covering more ground than what they used to in ruby-kafka.

We also need to organize this properly. Splitting subscribers looks like a natural next step.