### PR TITLE
fix: Call error handler with exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,12 +455,8 @@ If, on the other hand, the exception was cause by a temporary network or databas
 In addition to retrying the processing of messages, Racecar also allows defining an _error handler_ callback that is invoked whenever an exception is raised by your `#process` method. This allows you to track and report errors to a monitoring system:
 
 ```ruby
-Racecar.config.on_error do |exception, info|
-  MyErrorTracker.report(exception, {
-    topic: info[:topic],
-    partition: info[:partition],
-    offset: info[:offset],
-  })
+Racecar.config.on_error do |exception|
+  MyErrorTracker.report(exception)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -455,8 +455,12 @@ If, on the other hand, the exception was cause by a temporary network or databas
 In addition to retrying the processing of messages, Racecar also allows defining an _error handler_ callback that is invoked whenever an exception is raised by your `#process` method. This allows you to track and report errors to a monitoring system:
 
 ```ruby
-Racecar.config.on_error do |exception|
-  MyErrorTracker.report(exception)
+Racecar.config.on_error do |exception, info|
+  MyErrorTracker.report(exception, {
+    topic: info[:topic],
+    partition: info[:partition],
+    offset: info[:offset],
+  })
 end
 ```
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -206,6 +206,7 @@ module Racecar
       rescue => e
         desc = "#{topic}/#{partition}"
         logger.error "Failed to process #{desc} at #{offsets}: #{e}"
+        config.error_handler.call(e)
 
         pause = pauses[topic][partition]
         logger.warn "Pausing partition #{desc} for #{pause.backoff_interval} seconds"

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -303,6 +303,15 @@ RSpec.shared_examples "pause handling" do
     expect(kafka.consumers.first._paused).to eq true
   end
 
+  it "calls error handler" do
+    error = StandardError.new("surprise")
+    expect(config.error_handler).to receive(:call).at_least(:once).with(error)
+
+    kafka.deliver_message(error, topic: "greetings")
+
+    runner.run
+  end
+
   context 'with instrumentation enabled' do
     let(:pause_instrumentation) do
       {

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -303,15 +303,6 @@ RSpec.shared_examples "pause handling" do
     expect(kafka.consumers.first._paused).to eq true
   end
 
-  it "calls error handler" do
-    error = StandardError.new("surprise")
-    expect(config.error_handler).to receive(:call).at_least(:once).with(error)
-
-    kafka.deliver_message(error, topic: "greetings")
-
-    runner.run
-  end
-
   context 'with instrumentation enabled' do
     let(:pause_instrumentation) do
       {
@@ -371,6 +362,26 @@ RSpec.describe Racecar::Runner do
       runner.run
 
       expect(processor.messages.map(&:value)).to eq ["hello world"]
+    end
+
+    it "calls error handler when an exception is raised" do
+      error = StandardError.new("surprise")
+      info = {
+        consumer_class: 'TestConsumer',
+        topic: 'greetings',
+        partition: 0,
+        offset: 0,
+        create_time: nil,
+        key: nil,
+        value: error,
+        headers: nil
+      }
+
+      expect(config.error_handler).to receive(:call).at_least(:once).with(error, info)
+
+      kafka.deliver_message(error, topic: "greetings")
+
+      runner.run
     end
 
     context 'with instrumentation enabled' do
@@ -463,6 +474,24 @@ RSpec.describe Racecar::Runner do
       runner.run
 
       expect(processor.messages.map(&:value)).to eq ["hello world"]
+    end
+
+    it "calls error handler when an exception is raised" do
+      error = StandardError.new("surprise")
+      info = {
+        consumer_class: 'TestBatchConsumer',
+        topic: 'greetings',
+        partition: 0,
+        first_offset: 0,
+        last_offset: 0,
+        message_count: 1,
+      }
+
+      expect(config.error_handler).to receive(:call).at_least(:once).with(error, info)
+
+      kafka.deliver_message(error, topic: "greetings")
+
+      runner.run
     end
 
     context 'with instrumentation enabled' do


### PR DESCRIPTION
This ensures that the global error handler is called when a runner is configured with a pause timeout.  I've also updated the README to remove the `info` argument as I don't see `error_handler` called with it anywhere.