### PR TITLE
Fix missing constant error

### DIFF
--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -26,7 +26,7 @@ module Racecar
       end
 
       def host
-        @host ||= default_host
+        @host
       end
 
       def host=(host)
@@ -35,7 +35,7 @@ module Racecar
       end
 
       def port
-        @port ||= default_port
+        @port
       end
 
       def port=(port)
@@ -62,22 +62,6 @@ module Racecar
       end
 
       private
-
-      def default_host
-        if ::Datadog::Statsd.const_defined?(:Connection)
-          ::Datadog::Statsd::Connection::DEFAULT_HOST
-        else
-          ::Datadog::Statsd::DEFAULT_HOST
-        end
-      end
-
-      def default_port
-        if ::Datadog::Statsd.const_defined?(:Connection)
-          ::Datadog::Statsd::Connection::DEFAULT_PORT
-        else
-          ::Datadog::Statsd::DEFAULT_PORT
-        end
-      end
 
       def clear
         @statsd && @statsd.close

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "timecop"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 4.7.0"
+  spec.add_development_dependency "dogstatsd-ruby", ">= 4.0.0", "< 5.0.0"
   spec.add_development_dependency "activesupport", ">= 4.0", "< 6.1"
 end

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "timecop"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 5.0.0"
+  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 4.7.0"
   spec.add_development_dependency "activesupport", ">= 4.0", "< 6.1"
 end


### PR DESCRIPTION
## Why?

Because dogstatsd-ruby moved some constants around. I was getting these errors when running specs:

> uninitialized constant Datadog::Statsd::Connection::DEFAULT_HOST

## How?

Apply the suggestion from https://github.com/zendesk/ruby-kafka/pull/810#issuecomment-589415255

Note: Similar to the change I made in https://github.com/zendesk/ruby-kafka/pull/810 but only had to go back one minor version instead of 2.