### PR TITLE
Add time_lag metric to process_batch instrumentation_payload

### DIFF
--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -126,6 +126,8 @@ module Racecar
       def process_batch(event)
         offset = event.payload.fetch(:last_offset)
         messages = event.payload.fetch(:message_count)
+        last_create_time = event.payload.fetch(:last_create_time)
+        time_lag = last_create_time && ((Time.now - last_create_time) * 1000).to_i
         tags = default_tags(event)
 
         if event.payload.key?(:exception)
@@ -136,6 +138,10 @@ module Racecar
         end
 
         gauge("consumer.offset", offset, tags: tags)
+
+        if time_lag
+          gauge("consumer.time_lag", time_lag, tags: tags)
+        end
       end
 
       def join_group(event)

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -188,6 +188,7 @@ module Racecar
         partition:      first.partition,
         first_offset:   first.offset,
         last_offset:    last.offset,
+        last_create_time: last.timestamp,
         message_count:  messages.size
       }
 

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Racecar::Datadog::ConsumerSubscriber do
         partition:      1,
         first_offset:   3,
         last_offset:    10,
+        last_create_time: Time.now,
         message_count:  20,
       )
     end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -484,6 +484,7 @@ RSpec.describe Racecar::Runner do
         partition: 0,
         first_offset: 0,
         last_offset: 0,
+        last_create_time: nil,
         message_count: 1,
       }
 
@@ -502,6 +503,7 @@ RSpec.describe Racecar::Runner do
           partition:      0,
           first_offset:   0,
           last_offset:    0,
+          last_create_time: nil,
           message_count:  1
         }
       end


### PR DESCRIPTION
## Why?

As explained in https://github.com/zendesk/ruby-kafka/pull/811 we're excited to try out racecar 2 beta but need a metric for lag in the process_batch instrumentation. It doesn't look like offset_lag will be possible initially but the time_lag metric available in the process_message metrics would be useful to us if added to the process_batch metrics

## How?

Adds time_lag to process_batch metrics.