### PR TITLE
[v1-stable] Added error handling for required libraries

### DIFF
--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -102,7 +102,12 @@ module Racecar
         opts.on("-r", "--require STRING", "Require a library before starting the consumer") do |lib|
           $LOAD_PATH.unshift(Dir.pwd) unless load_path_modified
           load_path_modified = true
-          require lib
+          begin
+            require lib
+          rescue => e
+            $stderr.puts "=> #{lib} failed to load: #{e.message}"
+            exit
+          end
         end
 
         opts.on("-l", "--log STRING", "Log to the specified file") do |logfile|

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -27,4 +27,13 @@ RSpec.describe Racecar::Cli do
 
     Racecar::Cli.main(args)
   end
+
+  it "outputs a helpful message and exits if the required library fails to load" do
+    args = ["--require", "./spec/support/bad_library.rb", "BadLibrary::BadConsumer"]
+    expected_output = "=> ./spec/support/bad_library.rb failed to load: BadLibrary failed to load\n"
+
+    expect {
+      Racecar::Cli.main(args)
+    }.to raise_error(SystemExit).and output(expected_output).to_stderr
+  end
 end

--- a/spec/support/bad_library.rb
+++ b/spec/support/bad_library.rb
@@ -1,0 +1,3 @@
+module BadLibrary
+  raise StandardError, "BadLibrary failed to load"
+end


### PR DESCRIPTION
If a required library failed to load then the failure would be silently swallowed.  The error handling added here now sends the error message to STDERR.

This PR addresses #143 for the `v1-stable` branch.