### PR TITLE
SSL Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,9 @@ The memory usage limit is roughly estimated as `max_bytes * min_message_queue_si
 * `ssl_crl_location` – Path to CRL for verifying broker's certificate validity
 * `ssl_keystore_location` – Path to client's keystore (PKCS#12) used for authentication
 * `ssl_keystore_password` – Client's keystore (PKCS#12) password
+* `ssl_certificate_location` – Path to the certificate
+* `ssl_key_location` – Path to client's certificate used for authentication
+* `ssl_key_password` – Client's certificate password
 
 #### SASL encryption, authentication & authorization
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -82,6 +82,15 @@ module Racecar
     desc "Client's keystore (PKCS#12) password"
     string :ssl_keystore_password
 
+    desc "Path to the certificate used for authentication"
+    string :ssl_certificate_location
+
+    desc "Path to client's certificate used for authentication"
+    string :ssl_key_location
+
+    desc "Client's certificate password"
+    string :ssl_key_password
+
     desc "SASL mechanism to use for authentication"
     string :sasl_mechanism, allowed_values: %w{GSSAPI PLAIN SCRAM-SHA-256 SCRAM-SHA-512}
 
@@ -217,6 +226,9 @@ module Racecar
         "ssl.crl.location" => ssl_crl_location,
         "ssl.keystore.location" => ssl_keystore_location,
         "ssl.keystore.password" => ssl_keystore_password,
+        "ssl.certificate.location" => ssl_certificate_location,
+        "ssl.key.location" => ssl_key_location,
+        "ssl.key.password" => ssl_key_password,
         "sasl.mechanism" => sasl_mechanism,
         "sasl.kerberos.service.name" => sasl_kerberos_service_name,
         "sasl.kerberos.principal" => sasl_kerberos_principal,


### PR DESCRIPTION
#### Description
Add a new configuration options: `ssl_certificate_location`, `ssl_key_location` and `ssl_key_password` that will get passed down to rdkafka in order to configure the certificate location.

In order to configure properly the authentication, we need to specify a certificate path too, which we currently do not: https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka#configure-librdkafka-client

Also, per the librdkafka documentation linked above ☝️ from the client perspective, we should be sending `ssl.key.location` and `ssl.key.password` too.