### PR TITLE
Move the instrumentation of `process_message` closer

### DIFF
--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -166,16 +166,16 @@ module Racecar
       }
 
       @instrumenter.instrument("start_process_message", instrumentation_payload)
-      @instrumenter.instrument("process_message", instrumentation_payload) do
-        with_pause(message.topic, message.partition, message.offset..message.offset) do
-          begin
+      with_pause(message.topic, message.partition, message.offset..message.offset) do
+        begin
+          @instrumenter.instrument("process_message", instrumentation_payload) do
             processor.process(Racecar::Message.new(message))
             processor.deliver!
             consumer.store_offset(message)
-          rescue => e
-            config.error_handler.call(e, instrumentation_payload)
-            raise e
           end
+        rescue => e
+          config.error_handler.call(e, instrumentation_payload)
+          raise e
         end
       end
     end


### PR DESCRIPTION
When exceptions were being raised by processing code, the `with_pause` method would swallow them if pausing was configured, meaning that the instrumentation code would never see the exception