### PR TITLE
Add a new configuration value to run multiple consumers in separate threads.

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -148,8 +148,8 @@ module Racecar
     desc "Whether to boot Rails when starting the consumer"
     boolean :without_rails, default: false
 
-    desc "Run the racecar process as a standalone process or use threads within a existing process"
-    boolean :standalone, default: true
+    desc "Run the racecar process with multiple threads and one thread per consumer"
+    boolean :threaded, default: false
 
     # The error handler must be set directly on the object.
     attr_reader :error_handler
@@ -205,7 +205,8 @@ module Racecar
     end
 
     def rdkafka_consumer
-      consumer_config = consumer.map do |param|
+    # TODO: Investigate the intermittent nil values in consumer.
+      consumer_config = consumer.compact.map do |param|
         param.split("=", 2).map(&:strip)
       end.to_h
       consumer_config.merge!(rdkafka_security_config)
@@ -213,7 +214,7 @@ module Racecar
     end
 
     def rdkafka_producer
-      producer_config = producer.map do |param|
+      producer_config = producer.compact.map do |param|
         param.split("=", 2).map(&:strip)
       end.to_h
       producer_config.merge!(rdkafka_security_config)

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -148,6 +148,9 @@ module Racecar
     desc "Whether to boot Rails when starting the consumer"
     boolean :without_rails, default: false
 
+    desc "Run the racecar process as a standalone process or use threads within a existing process"
+    boolean :standalone, default: true
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -15,7 +15,7 @@ module Racecar
 
     def poll(timeout_ms)
       maybe_select_next_consumer
-      started_at ||= Time.now
+      started_at ||= Process.clock_gettime(Process::CLOCK_MONOTONIC)
       try ||= 0
       remain ||= timeout_ms
 
@@ -43,7 +43,7 @@ module Racecar
 
     # XXX: messages are not guaranteed to be from the same partition
     def batch_poll(timeout_ms)
-      @batch_started_at = Time.now
+      @batch_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       @messages = []
       while collect_messages_for_batch? do
         remain = remaining_time_ms(timeout_ms, @batch_started_at)
@@ -162,7 +162,7 @@ module Racecar
 
     def collect_messages_for_batch?
       @messages.size < @config.fetch_messages &&
-      (Time.now - @batch_started_at) < @config.max_wait_time
+      (Process.clock_gettime(Process::CLOCK_MONOTONIC) - @batch_started_at) < @config.max_wait_time
     end
 
     def rdkafka_config(subscription)
@@ -190,7 +190,7 @@ module Racecar
     end
 
     def remaining_time_ms(limit_ms, started_at_time)
-      r = limit_ms - ((Time.now - started_at_time)*1000).round
+      r = limit_ms - ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at_time)*1000)
       r <= 0 ? 0 : r
     end
   end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -42,7 +42,7 @@ module Racecar
     end
 
     def run
-      install_signal_handlers if config.standalone
+      install_signal_handlers unless config.threaded
 
       @stop_requested = false
 
@@ -77,13 +77,14 @@ module Racecar
         end
       end
 
-      logger.info "Gracefully shutting down"
+      logger.info "Gracefully shutting down #{processor.class}"
       processor.deliver!
       processor.teardown
       consumer.commit
       @instrumenter.instrument('leave_group') do
         consumer.close
       end
+      logger.info "Graceful shutdown of #{processor.class} completed"
     end
 
     def stop

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -42,7 +42,8 @@ module Racecar
     end
 
     def run
-      install_signal_handlers
+      install_signal_handlers if config.standalone
+
       @stop_requested = false
 
       # Configure the consumer with a producer so it can produce messages and


### PR DESCRIPTION
This is a draft PR to try multiple consumers using threads.
1. Support multiple consumers using threads when `threaded` option is passed.
2. Shutdown all the consumers in different threads.

This is tested using `rdkafka-ruby:master` branch that supports JRuby.

```
## test_multiple.rb

Racecar.configure do |config|
  # Each config variable can be set using a writer attribute.
  config.brokers = ['localhost:9092']
end

class TestConsumer1 < Racecar::Consumer
  subscribes_to "topic1"
  group_id = 'test1'

  def process(message)
    p "#{self.class} #{message.value} #{message.offset}"
  end
end

class TestConsumer2 < Racecar::Consumer
  subscribes_to "topic2"
  group_id = 'test2'

  def process(message)
    p "#{self.class} #{message.value} #{message.offset}"
 end
end
```

**Command:**

` bundle exec racecar --require ./test_multiple.rb --threaded TestConsumer1 TestConsumer2`

**Result:**
```
$ bundle exec racecar --require ./test_multiple.rb --threaded TestConsumer1 TestConsumer2
=> Starting Racecar consumer TestConsumer1, TestConsumer2...
=> Wrooooom!
=> Ctrl-C to shutdown consumer
Starting consumer TestConsumer1
The signal QUIT is in use by the JVM and will not work correctly on this platform
The signal USR1 is in use by the JVM and will not work correctly on this platform
Starting consumer TestConsumer2
W, [2020-03-10T16:35:13.388905 #372]  WARN -- : ActiveSupport::Notifications not available, instrumentation is disabled
W, [2020-03-10T16:35:13.389168 #372]  WARN -- : ActiveSupport::Notifications not available, instrumentation is disabled
^CI, [2020-03-10T16:35:15.001110 #372]  INFO -- : Gracefully shutting down TestConsumer2
I, [2020-03-10T16:35:15.001110 #372]  INFO -- : Gracefully shutting down TestConsumer1
E, [2020-03-10T16:35:15.006739 #372] ERROR -- : rdkafka: [thrd:GroupCoordinator]: 1/1 brokers are down
I, [2020-03-10T16:35:15.006740 #372]  INFO -- : Graceful shutdown of TestConsumer1 completed
I, [2020-03-10T16:35:15.007616 #372]  INFO -- : Graceful shutdown of TestConsumer2 completed
```
 