### PR TITLE
Rename message.max.bytes configuration

### DIFF
--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -174,7 +174,7 @@ module Racecar
         "client.id"               => @config.client_id,
         "enable.partition.eof"    => false,
         "fetch.max.bytes"         => @config.max_bytes,
-        "fetch.message.max.bytes" => subscription.max_bytes_per_partition,
+        "message.max.bytes"       => subscription.max_bytes_per_partition,
         "fetch.wait.max.ms"       => @config.max_wait_time * 1000,
         "group.id"                => @config.group_id,
         "heartbeat.interval.ms"   => @config.heartbeat_interval * 1000,


### PR DESCRIPTION
According to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md this setting should be called `message.max.bytes` instead of `fetch.message.max.bytes` which explains why if you set `fetch.max.bytes` to something smaller than the default `message.max.bytes` you see this error:

```
`fetch.max.bytes` must be >= `message.max.bytes` (Rdkafka::Config::ClientCreationError)
```