### PR TITLE
Require ruby-kafka v1.0 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Require ruby-kafka v1.0 or higher.
+* Add error handling for required libraries (#149).
+
+## racecar v1.0.1
+
+* Add `--without-rails` option to boot consumer without Rails (#139).
+
 ## racecar v1.0.0
 
 Unchanged from v0.5.0.

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "king_konf", "~> 0.3.7"
-  spec.add_runtime_dependency "ruby-kafka", "~> 0.7.8"
+  spec.add_runtime_dependency "ruby-kafka", "~> 1.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This change is against the v1-stable branch to create a racecar version that can be used with ruby-kafka v1.0.

I've also updated the CHANGELOG with recent changes.