### PR TITLE
Bring back `partition_key`

### DIFF
--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -54,13 +54,14 @@ module Racecar
     protected
 
     # https://github.com/appsignal/rdkafka-ruby#producing-messages
-    def produce(payload, topic:, key:, headers: nil, create_time: nil)
+    def produce(payload, topic:, key:, partition_key: nil, headers: nil, create_time: nil)
       @delivery_handles ||= []
       message_size = payload.respond_to?(:bytesize) ? payload.bytesize : 0
       instrumentation_payload = {
         value: payload,
         headers: headers,
         key: key,
+        partition_key: partition_key,
         topic: topic,
         message_size: message_size,
         create_time: Time.now,
@@ -72,6 +73,7 @@ module Racecar
           topic: topic,
           payload: payload,
           key: key,
+          partition_key: partition_key,
           timestamp: create_time,
           headers: headers,
         )

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "king_konf", "~> 0.3.7"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.7.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.8.0.beta.1"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "rake", "> 10.0"

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -154,7 +154,7 @@ class FakeProducer
     @delivery_callback = nil
   end
 
-  def produce(payload:, topic:, key:, timestamp: nil, headers: nil)
+  def produce(payload:, topic:, key:, partition_key: nil, timestamp: nil, headers: nil)
     @buffer << FakeRdkafka::FakeMessage.new(payload, key, topic, 0, 0, timestamp, headers)
     FakeDeliveryHandle.new(@kafka, @buffer.last, @delivery_callback)
   end


### PR DESCRIPTION
This should ensure backwards compatibility with Racecar v1.