### PR TITLE
Add ssl_client_cert_key_password config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Support for `ssl_client_cert_key_password`
+
 ## racecar v1.1.0
 
 * Require ruby-kafka v1.0 or higher.

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ The memory usage limit is roughly estimated as `max_bytes * max_fetch_queue_size
 * `ssl_ca_cert_file_path` - The path to a valid SSL certificate authority file.
 * `ssl_client_cert` – A valid SSL client certificate, as a string.
 * `ssl_client_cert_key` – A valid SSL client certificate key, as a string.
+* `ssl_client_cert_key_password` – The password for the client cert key, as a string (optional).
 
 #### SASL encryption, authentication & authorization
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -73,6 +73,9 @@ module Racecar
     desc "A valid SSL client certificate key"
     string :ssl_client_cert_key
 
+    desc "The password for the SSL client certificate key"
+    string :ssl_client_cert_key_password
+
     desc "Support for using the CA certs installed on your system by default for SSL. More info, see: https://github.com/zendesk/ruby-kafka/pull/521"
     boolean :ssl_ca_certs_from_system, default: false
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -173,7 +173,7 @@ module Racecar
       end
 
       if ssl_client_cert_key_password && !ssl_client_cert_key
-        raise ConfigError, "`ssl_client_cert_key_passowrd` must be used in conjunction with `ssl_client_cert_key`"
+        raise ConfigError, "`ssl_client_cert_key_password` must be used in conjunction with `ssl_client_cert_key`"
       end
     end
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -171,6 +171,10 @@ module Racecar
       if max_pause_timeout && !pause_with_exponential_backoff?
         raise ConfigError, "`max_pause_timeout` only makes sense when `pause_with_exponential_backoff` is enabled"
       end
+
+      if ssl_client_cert_key_password && !ssl_client_cert_key
+        raise ConfigError, "`ssl_client_cert_key_passowrd` must be used in conjunction with `ssl_client_cert_key`"
+      end
     end
 
     def load_consumer_class(consumer_class)

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -27,6 +27,7 @@ module Racecar
         ssl_ca_cert_file_path: config.ssl_ca_cert_file_path,
         ssl_client_cert: config.ssl_client_cert,
         ssl_client_cert_key: config.ssl_client_cert_key,
+        ssl_client_cert_key_password: config.ssl_client_cert_key_password,
         sasl_plain_username: config.sasl_plain_username,
         sasl_plain_password: config.sasl_plain_password,
         sasl_scram_username: config.sasl_scram_username,

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Racecar::Config do
       expect {
         # config.ssl_client_cert_key = "somekey"
         config.validate!
-      }.to raise_exception(Racecar::ConfigError, "`ssl_client_cert_key_passowrd` must be used in conjunction with `ssl_client_cert_key`")
+      }.to raise_exception(Racecar::ConfigError, "`ssl_client_cert_key_password` must be used in conjunction with `ssl_client_cert_key`")
 
       expect {
         config.ssl_client_cert_key = "somekey"

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -152,6 +152,20 @@ RSpec.describe Racecar::Config do
         config.validate!
       }.to raise_exception(Racecar::ConfigError, "`max_pause_timeout` only makes sense when `pause_with_exponential_backoff` is enabled")
     end
+
+    it "raises an exception when if ssl_client_cert_key_password is provided when ssl_client_cert_key is not provided" do
+      config.ssl_client_cert_key_password = "password"
+
+      expect {
+        # config.ssl_client_cert_key = "somekey"
+        config.validate!
+      }.to raise_exception(Racecar::ConfigError, "`ssl_client_cert_key_passowrd` must be used in conjunction with `ssl_client_cert_key`")
+
+      expect {
+        config.ssl_client_cert_key = "somekey"
+        config.validate!
+      }.not_to raise_exception
+    end
   end
 
   describe "#inspect" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe Racecar::Config do
     }.to raise_exception(KingKonf::ConfigError)
   end
 
+  it "accepts ssl_client_cert_key_password" do
+    expect {
+      config.ssl_client_cert_key_password = "foobar"
+    }.not_to raise_exception
+  end
+
   describe "#load_env" do
     it "sets the brokers from RACECAR_BROKERS" do
       ENV["RACECAR_BROKERS"] = "hansel,gretel"


### PR DESCRIPTION
For use with password-secured SSL client cert keys.