### PR TITLE
add instrumentation at the start of main_loop

### DIFF
--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -61,8 +61,10 @@ module Racecar
       # Main loop
       loop do
         break if @stop_requested
-        resume_paused_partitions
+        @instrumenter.instrument("start_main_loop", instrumentation_payload)
         @instrumenter.instrument("main_loop", instrumentation_payload) do
+          resume_paused_partitions
+
           case process_method
           when :batch then
             msg_per_part = consumer.batch_poll(config.max_wait_time).group_by(&:partition)

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -415,6 +415,14 @@ RSpec.describe Racecar::Runner do
         runner.run
       end
 
+      it 'instruments the start of main_loop' do
+        expect(instrumenter).
+          to receive(:instrument).
+          with("start_main_loop", hash_including(loop_instrumentation))
+
+        runner.run
+      end
+
       it 'instruments the start of processing a message' do
         expect(instrumenter).
           to receive(:instrument).


### PR DESCRIPTION
Akin to the other instrumentations `start_process_message`/`start_process_batch`, allow to subscribe to start of main loop. My use case is to more easily connect a "request oriented" logging framework in use at my org, i.e. I have an actual use case for this.