### PR TITLE
fix edge case where no retries were done for batch_poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * [Bugfix] Close RdKafka consumer in ConsumerSet#reset_current_consumer to prevent memory leak (#196)
+* [Bugfix] `poll`/`batch_poll` would not retry in edge cases and raise immediately. They still honor the `max_wait_time` setting, but might return no messages instead and only retry on their next call. ([#177](https://github.com/zendesk/racecar/pull/177))
 
 ## racecar v2.1.0
 

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -126,12 +126,12 @@ module Racecar
 
       poll_current_consumer(max_wait_time_ms)
     rescue Rdkafka::RdkafkaError => e
-      @logger.error "(try #{try}): Error for topic subscription #{current_subscription}: #{e}"
-
       remain_ms = remaining_time_ms(max_wait_time_ms, started_at)
       wait_ms = 100 * (2**try) # 100ms, 200ms, 400ms, …
 
       try += 1
+      @logger.error "(try #{try}): Error for topic subscription #{current_subscription}: #{e}"
+
       raise if try >= MIN_POLL_TRIES && wait_ms >= remain_ms
       raise if try >= MAX_POLL_TRIES
 

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -127,6 +127,7 @@ module Racecar
 
       wait_ms = try == 0 ? 0 : 50 * (2**try) # 0ms, 100ms, 200ms, 400ms, …
       if wait_ms >= max_wait_time_ms && remain_ms > 1
+        @logger.debug "Capping #{wait_ms}ms to #{max_wait_time_ms-1}ms."
         sleep (max_wait_time_ms-1)/1000.0
         remain_ms = 1
       elsif wait_ms >= remain_ms
@@ -141,6 +142,7 @@ module Racecar
       poll_current_consumer(remain_ms)
     rescue Rdkafka::RdkafkaError => e
       try += 1
+      @instrumenter.instrument("poll_retry", try: try, rdkafka_time_limit: remain_ms, exception: e)
       @logger.error "(try #{try}/#{MAX_POLL_TRIES}): Error for topic subscription #{current_subscription}: #{e}"
       raise if try >= MAX_POLL_TRIES
       retry

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -157,6 +157,15 @@ module Racecar
         end
       end
 
+      def poll_retry(event)
+        tags = {
+          client: event.payload.fetch(:client_id),
+          group_id: event.payload.fetch(:group_id),
+        }
+        rdkafka_error_code = event.payload.fetch(:exception).code.to_s.gsub(/\W/, '')
+        increment("consumer.poll.rdkafka_error.#{rdkafka_error_code}", tags: tags)
+      end
+
       def main_loop(event)
         tags = {
           client: event.payload.fetch(:client_id),


### PR DESCRIPTION
The edge case looks something like this:
1. `batch_poll` iterates just fine until a very short amount of time is left, say 1ms
2. It will trigger another `poll`, which can of course fail
3. there is no time left to do any retry, thus immediately it will immediately re-raise and let the error bubble

Since the code was tough to follow already, I decided to refactor it instead of hacking the `MIN_POLL_TRIES` feature in. I adjusted the signature of `batch_poll`, even though that is not strictly needed. It just seemed weird to require `max_wait_time`/`timeout_ms` to be passed in, while the `max_messages` was "hard"coded to `@config.fetch_messages`. It's backwards compatible.

There's also another change, since rdkafka now always gets passed the `max_wait_time` instead of the `remain_ms`. This is to give it enough time for a real retry, e.g. when only 1ms remains and there were connection hiccups.