### PR TITLE
Adding support to OAUTHBEARER authentication (sasl_oauth_token_provider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,11 +319,12 @@ If using SCRAM:
 
 If using OAUTHBEARER:
 
-* `sasl_oauth_token_provider`- This mechanism is supported in kafka >= 2.0.0 as of KIP-255
-
-In order to authenticate using OAUTHBEARER, you must set the client with an instance of a class that implements a token method (the interface is described in Kafka::Sasl::OAuth) which returns an ID/Access token.
+* `sasl_oauth_token_provider`- In order to authenticate using OAUTHBEARER, you must set the client with an instance of a class that implements a token method (the interface is described in Kafka::Sasl::OAuth) which returns an ID/Access token.
+This mechanism is supported in kafka >= 2.0.0 as of KIP-255
 
 See more at [https://github.com/zendesk/ruby-kafka/tree/master#oauthbearer](https://github.com/zendesk/ruby-kafka/tree/master#oauthbearer)
+
+NOTE: `sasl_oauth_token_provider` only works using `config/racecar.rb` configuration file.
 
 #### Producing messages
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,14 @@ If using SCRAM:
 * `sasl_scram_password` – The password used to authenticate.
 * `sasl_scram_mechanism` – The SCRAM mechanism to use, either `sha256` or `sha512`.
 
+If using OAUTHBEARER:
+
+* `sasl_oauth_token_provider`- This mechanism is supported in kafka >= 2.0.0 as of KIP-255
+
+In order to authenticate using OAUTHBEARER, you must set the client with an instance of a class that implements a token method (the interface is described in Kafka::Sasl::OAuth) which returns an ID/Access token.
+
+See more at [https://github.com/zendesk/ruby-kafka/tree/master#oauthbearer](https://github.com/zendesk/ruby-kafka/tree/master#oauthbearer)
+
 #### Producing messages
 
 These settings are related to consumers that _produce messages to Kafka_.

--- a/README.md
+++ b/README.md
@@ -320,11 +320,11 @@ If using SCRAM:
 If using OAUTHBEARER:
 
 * `sasl_oauth_token_provider`- In order to authenticate using OAUTHBEARER, you must set the client with an instance of a class that implements a token method (the interface is described in Kafka::Sasl::OAuth) which returns an ID/Access token.
-This mechanism is supported in kafka >= 2.0.0 as of KIP-255
+This mechanism is supported in kafka >= 2.0.0 as of KIP-255.
 
-See more at [https://github.com/zendesk/ruby-kafka/tree/master#oauthbearer](https://github.com/zendesk/ruby-kafka/tree/master#oauthbearer)
+See more at [here](https://github.com/zendesk/ruby-kafka/tree/master#oauthbearer).
 
-NOTE: `sasl_oauth_token_provider` only works using `config/racecar.rb` configuration file.
+NOTE: `sasl_oauth_token_provider` only works using the `config/racecar.rb` configuration file.
 
 #### Producing messages
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -4,9 +4,6 @@ module Racecar
   class Config < KingKonf::Config
     env_prefix :racecar
 
-    desc "The OAUTHBEARER token provider class"
-    attr_accessor :sasl_oauth_token_provider
-
     desc "A list of Kafka brokers in the cluster that you're consuming from"
     list :brokers, default: ["localhost:9092"]
 
@@ -143,6 +140,9 @@ module Racecar
     attr_reader :error_handler
 
     attr_accessor :subscriptions, :logger
+
+    # The OAUTHBEARER token provider class.
+    attr_accessor :sasl_oauth_token_provider
 
     def initialize(env: ENV)
       super(env: env)

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -103,6 +103,9 @@ module Racecar
     desc "The SCRAM mechanism to use, either `sha256` or `sha512`"
     string :sasl_scram_mechanism, allowed_values: ["sha256", "sha512"]
 
+    desc "The OAUTHBEARER token provider class"
+    string :sasl_oauth_token_provider
+
     desc "Whether to use SASL over SSL."
     boolean :sasl_over_ssl, default: true
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -4,6 +4,9 @@ module Racecar
   class Config < KingKonf::Config
     env_prefix :racecar
 
+    desc "The OAUTHBEARER token provider class"
+    attr_accessor :sasl_oauth_token_provider
+
     desc "A list of Kafka brokers in the cluster that you're consuming from"
     list :brokers, default: ["localhost:9092"]
 
@@ -102,9 +105,6 @@ module Racecar
 
     desc "The SCRAM mechanism to use, either `sha256` or `sha512`"
     string :sasl_scram_mechanism, allowed_values: ["sha256", "sha512"]
-
-    desc "The OAUTHBEARER token provider class"
-    string :sasl_oauth_token_provider
 
     desc "Whether to use SASL over SSL."
     boolean :sasl_over_ssl, default: true

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -33,6 +33,7 @@ module Racecar
         sasl_scram_username: config.sasl_scram_username,
         sasl_scram_password: config.sasl_scram_password,
         sasl_scram_mechanism: config.sasl_scram_mechanism,
+        sasl_oauth_token_provider: config.sasl_oauth_token_provider,
         sasl_over_ssl: config.sasl_over_ssl,
         ssl_ca_certs_from_system: config.ssl_ca_certs_from_system,
         ssl_verify_hostname: config.ssl_verify_hostname

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe Racecar::Config do
     }.not_to raise_exception
   end
 
+  it "accepts sasl_oauth_token_provider" do
+    expect {
+      config.sasl_oauth_token_provider = Class.new
+    }.not_to raise_exception
+  end
+
   describe "#load_env" do
     it "sets the brokers from RACECAR_BROKERS" do
       ENV["RACECAR_BROKERS"] = "hansel,gretel"


### PR DESCRIPTION
Based on https://github.com/zendesk/ruby-kafka/tree/master#oauthbearer

I am adding the sasl_oauth_token_provider configuration, so we can use the oauthbearer from ruby-kafka.

--- 

```
Racecar.configure do |config|
  config.brokers = "localhost:9094"
  config.client_id =  "client"
  config.sasl_oauth_token_provider =  TokenProvider.new
  config.ssl_ca_certs_from_system = true
end
```

```
I, [2020-08-12T10:43:55.007741 #51439]  INFO -- : New topics added to target list: my-topic-name
I, [2020-08-12T10:43:55.007852 #51439]  INFO -- : Fetching cluster metadata from kafka://localhost:9094
D, [2020-08-12T10:43:56.196415 #51439] DEBUG -- : Obtaining new OAuth token
I, [2020-08-12T10:43:58.037736 #51439]  INFO -- : Discovered cluster metadata; nodes: localhost:9094 (node_id=0)
I, [2020-08-12T10:43:58.038700 #51439]  INFO -- : [[client] {}:] Joining group `group_name`
I, [2020-08-12T10:43:58.039412 #51439]  INFO -- : [[client] {}:] Will fetch at most 1048576 bytes at a time per partition from my-topic-name
I, [2020-08-12T10:43:58.039662 #51439]  INFO -- : [[client] {}:] Fetching cluster metadata from kafka://localhost:9094
I, [2020-08-12T10:43:58.039454 #51439]  INFO -- : [[client] {}:] Fetching cluster metadata from kafka://localhost:9094
I, [2020-08-12T10:43:59.677859 #51439]  INFO -- : [[client] {}:] Discovered cluster metadata; nodes: localhost:9094 (node_id=0)
I, [2020-08-12T10:43:59.678802 #51439]  INFO -- : [[client] {}:] There are no partitions to fetch from, sleeping for 1.0s
```