### PR TITLE
Fix max_wait_time usage

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -156,6 +156,10 @@ module Racecar
 
     attr_accessor :subscriptions, :logger
 
+    def max_wait_time_ms
+      max_wait_time * 1000
+    end
+
     def initialize(env: ENV)
       super(env: env)
       @error_handler = proc {}

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -176,7 +176,7 @@ module Racecar
         "fetch.max.bytes"         => @config.max_bytes,
         "message.max.bytes"       => subscription.max_bytes_per_partition,
         "fetch.min.bytes"         => @config.fetch_min_bytes,
-        "fetch.wait.max.ms"       => @config.max_wait_time * 1000,
+        "fetch.wait.max.ms"       => @config.max_wait_time_ms,
         "group.id"                => @config.group_id,
         "heartbeat.interval.ms"   => @config.heartbeat_interval * 1000,
         "max.poll.interval.ms"    => @config.max_poll_interval * 1000,

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -65,12 +65,12 @@ module Racecar
         @instrumenter.instrument("main_loop", instrumentation_payload) do
           case process_method
           when :batch then
-            msg_per_part = consumer.batch_poll(config.max_wait_time).group_by(&:partition)
+            msg_per_part = consumer.batch_poll(config.max_wait_time_ms).group_by(&:partition)
             msg_per_part.each_value do |messages|
               process_batch(messages)
             end
           when :single then
-            message = consumer.poll(config.max_wait_time)
+            message = consumer.poll(config.max_wait_time_ms)
             process(message) if message
           end
         end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -123,6 +123,14 @@ RSpec.describe Racecar::Config do
     end
   end
 
+  describe '#max_wait_time_ms' do
+    before { config.max_wait_time = 12 }
+
+    it 'returns max_wait_time in milliseconds' do
+      expect(config.max_wait_time_ms).to eq(12_000)
+    end
+  end
+
   describe "#validate!" do
     before do
       config.brokers = ["a"]


### PR DESCRIPTION
Hi team! 

While checking the Statsd metrics that were being sent we noticed that the `consumer.loop.duration` was being called very frequently and apparently not respecting the `max_wait_time` configuration.

After applying the change from this PR we got the expected result! 

I think I've found the places where the configuration was being sent as seconds but they were expected to be in milliseconds:

https://github.com/zendesk/racecar/blob/c9b50bac4830e6b4f8a25a73cedaff5653c0e9d9/lib/racecar/consumer_set.rb#L16

I added this method to `Racecar::Config` to convert it, but happy to do it differently if there's a better way.

I'm also not sure how to write a good test for this change... any suggestions?

Thanks in advance! 