### PR TITLE
Add integration test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+version: 2.1
+orbs:
+  ruby: circleci/ruby@0.1.2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.6.3-stretch-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install
+      - run: bundle exec rspec --exclude-pattern='spec/integration/*_spec.rb'
+  integration-tests:
+    docker:
+      - image: circleci/ruby:2.6.3-stretch-node
+      - image: wurstmeister/zookeeper
+      - image: wurstmeister/kafka:2.11-2.0.0
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9092
+          KAFKA_PORT: 9092
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_DELETE_TOPIC_ENABLE: true
+      - image: wurstmeister/kafka:2.11-2.0.0
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9093
+          KAFKA_PORT: 9093
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_DELETE_TOPIC_ENABLE: true
+      - image: wurstmeister/kafka:2.11-2.0.0
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9094
+          KAFKA_PORT: 9094
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_DELETE_TOPIC_ENABLE: true
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install
+      - run: bundle exec rspec --pattern='spec/integration/*_spec.rb'
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - build
+      - integration-tests

--- a/spec/integration/README.md
+++ b/spec/integration/README.md
@@ -1,0 +1,3 @@
+# Integration Specs
+
+These specs have access to a real Kafka cluster.

--- a/spec/integration/consumer_spec.rb
+++ b/spec/integration/consumer_spec.rb
@@ -1,0 +1,64 @@
+require "securerandom"
+require "racecar/cli"
+require "racecar/ctl"
+
+class EchoConsumer < Racecar::Consumer
+  subscribes_to "input"
+
+  self.group_id = "test-consumer-#{SecureRandom.hex(8)}"
+
+  def process(message)
+    produce message.value, key: message.key, topic: "output"
+  end
+end
+
+module IntegrationSupport
+  INCOMING_MESSAGES = []
+
+  CONSUMER = Thread.new do
+    consumer = Rdkafka::Config.new({
+      "bootstrap.servers": Racecar.config.brokers.join(","),
+      "client.id":         Racecar.config.client_id,
+      "group.id":          "racecar-tests",
+    }.merge(Racecar.config.rdkafka_consumer)).consumer
+
+    consumer.subscribe("output")
+
+    consumer.each do |message|
+      puts "Received message #{message}"
+      INCOMING_MESSAGES << message
+    end
+  end
+
+  def self.incoming_messages
+    INCOMING_MESSAGES
+  end
+end
+
+RSpec.describe "running a Racecar consumer" do
+  it "works" do
+    worker = Thread.new do
+      cli = Racecar::Cli.new(["EchoConsumer"])
+      cli.run
+    end
+
+    ctl = Racecar::Ctl.main %w(
+      produce -t input -v hello -k greetings
+    )
+
+    message = nil
+    attempt = 1
+
+    while message.nil? && attempt <= 10
+      puts "Waiting for message..."
+      sleep 2 ** attempt
+      message = IntegrationSupport.incoming_messages.last
+      attempt += 1
+    end
+
+    expect(message).not_to be_nil
+    expect(message.topic).to eq "output"
+    expect(message.payload).to eq "hello"
+    expect(message.key).to eq "greetings"
+  end
+end


### PR DESCRIPTION
Adds an initial integration test that integrates with a running Kafka cluster.

A bit messy at the moment, but will be improved over time.