### PR TITLE
Keep track of the number of retries when handling errors

### DIFF
--- a/lib/racecar/pause.rb
+++ b/lib/racecar/pause.rb
@@ -1,8 +1,10 @@
 module Racecar
   class Pause
+    attr_reader :pauses_count
+
     def initialize(timeout: nil, max_timeout: nil, exponential_backoff: false)
       @started_at = nil
-      @pauses = 0
+      @pauses_count = 0
       @timeout = timeout
       @max_timeout = max_timeout
       @exponential_backoff = exponential_backoff
@@ -11,7 +13,7 @@ module Racecar
     def pause!
       @started_at = Time.now
       @ends_at = @started_at + backoff_interval unless @timeout.nil?
-      @pauses += 1
+      @pauses_count += 1
     end
 
     def resume!
@@ -38,13 +40,13 @@ module Racecar
     end
 
     def reset!
-      @pauses = 0
+      @pauses_count = 0
     end
 
     def backoff_interval
       return Float::INFINITY if @timeout.nil?
 
-      backoff_factor = @exponential_backoff ? 2**@pauses : 1
+      backoff_factor = @exponential_backoff ? 2**@pauses_count : 1
       timeout = backoff_factor * @timeout
 
       timeout = @max_timeout if @max_timeout && timeout > @max_timeout

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -166,7 +166,7 @@ module Racecar
       }
 
       @instrumenter.instrument("start_process_message", instrumentation_payload)
-      with_pause(message.topic, message.partition, message.offset..message.offset) do
+      with_pause(message.topic, message.partition, message.offset..message.offset) do |pause|
         begin
           @instrumenter.instrument("process_message", instrumentation_payload) do
             processor.process(Racecar::Message.new(message))
@@ -174,6 +174,7 @@ module Racecar
             consumer.store_offset(message)
           end
         rescue => e
+          instrumentation_payload[:retries_count] = pause.pauses_count
           config.error_handler.call(e, instrumentation_payload)
           raise e
         end
@@ -194,12 +195,13 @@ module Racecar
 
       @instrumenter.instrument("start_process_batch", instrumentation_payload)
       @instrumenter.instrument("process_batch", instrumentation_payload) do
-        with_pause(first.topic, first.partition, first.offset..last.offset) do
+        with_pause(first.topic, first.partition, first.offset..last.offset) do |pause|
           begin
             processor.process_batch(messages.map {|message| Racecar::Message.new(message) })
             processor.deliver!
             consumer.store_offset(messages.last)
           rescue => e
+            instrumentation_payload[:retries_count] = pause.pauses_count
             config.error_handler.call(e, instrumentation_payload)
             raise e
           end
@@ -208,17 +210,17 @@ module Racecar
     end
 
     def with_pause(topic, partition, offsets)
-      return yield if config.pause_timeout == 0
+      pause = pauses[topic][partition]
+      return yield pause if config.pause_timeout == 0
 
       begin
-        yield
+        yield pause
         # We've successfully processed a batch from the partition, so we can clear the pause.
         pauses[topic][partition].reset!
       rescue => e
         desc = "#{topic}/#{partition}"
         logger.error "Failed to process #{desc} at #{offsets}: #{e}"
 
-        pause = pauses[topic][partition]
         logger.warn "Pausing partition #{desc} for #{pause.backoff_interval} seconds"
         consumer.pause(topic, partition, offsets.first)
         pause.pause!


### PR DESCRIPTION
This PR introduces a new `retries_count` key in the `info` hash passed to the configured error handler.

This can be useful in cases where we might want to limit the number of individual error occurrences that get reported to a exception notification service or even implement some sort of monitoring for errors.

The implementation takes advantage of the existent `Pause` class, which already keeps track of the number of times the runner had to pause for a given topic/partition. 

