### PR TITLE
issue #186: move rescue to exe/racecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 * [Instrumentation] if processors define a `statistics_callback`, it will be called once every second for every subscription or producer connection. The first argument will be a Hash, for contents see [librdkafka STATISTICS.md](https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md).
 * Add current directory to `$LOAD_PATH` only when `--require` option is used (#117).
 * Remove manual heartbeat support, see [Long-running message processing section in README](README.md#long-running-message-processing).
+* Rescue exceptions--then log and pass to `on_error`--at the outermost level of `exe/racecar`, so that exceptions raised outside `Cli.run` are not silently discarded (#186).
+* When exceptions with a `cause` are logged, recursively log the `cause` detail, separated by `--- Caused by: ---\n`.
 
 ## racecar v1.0.0
 

--- a/exe/racecar
+++ b/exe/racecar
@@ -17,13 +17,25 @@ module Racecar
     rescue SystemExit
       raise
     rescue Exception => e
-      $stderr.puts "=> Crashed: #{e.class}: #{e}\n#{e.backtrace.join("\n")}"
+      $stderr.puts "=> Crashed: #{exception_with_causes(e)}\n#{e.backtrace.join("\n")}"
 
       Racecar.config.error_handler.call(e)
 
       exit(1)
     else
       exit(0)
+    end
+
+    private
+
+    def exception_with_causes(e)
+      result = +"#{e.class}: #{e}"
+      if e.cause
+        result << "\n"
+        result << "--- Caused by: ---\n"
+        result << exception_with_causes(e.cause)
+      end
+      result
     end
   end
 end

--- a/exe/racecar
+++ b/exe/racecar
@@ -3,19 +3,30 @@
 require "racecar"
 require "racecar/cli"
 
-begin
-  Racecar::Cli.main(ARGV)
-rescue SignalException => e
-  # We might receive SIGTERM before our signal handler is installed.
-  if Signal.signame(e.signo) == "TERM"
-    exit(0)
-  else
-    raise
+module Racecar
+  class << self
+    def start(argv)
+      Cli.main(argv)
+    rescue SignalException => e
+      # We might receive SIGTERM before our signal handler is installed.
+      if Signal.signame(e.signo) == "TERM"
+        exit(0)
+      else
+        raise
+      end
+    rescue SystemExit
+      raise
+    rescue Exception => e
+      $stderr.puts "=> Crashed: #{e.class}: #{e}\n#{e.backtrace.join("\n")}"
+
+      # Racecar.config.error_handler.call(e)
+
+      exit(1)
+    else
+      exit(0)
+    end
   end
-rescue
-  # Exceptions are printed to STDERR and sent to the error handler
-  # in `Racecar::Cli#run`, so we don't need to do anything here.
-  exit(1)
-else
-  exit(0)
 end
+
+# Start your engines!
+Racecar.start(ARGV)

--- a/exe/racecar
+++ b/exe/racecar
@@ -19,7 +19,7 @@ module Racecar
     rescue Exception => e
       $stderr.puts "=> Crashed: #{e.class}: #{e}\n#{e.backtrace.join("\n")}"
 
-      # Racecar.config.error_handler.call(e)
+      Racecar.config.error_handler.call(e)
 
       exit(1)
     else

--- a/lib/racecar/instrumenter.rb
+++ b/lib/racecar/instrumenter.rb
@@ -11,6 +11,7 @@ module Racecar
       @default_payload = default_payload
 
       @backend = if defined?(ActiveSupport::Notifications)
+        require 'concurrent/utility/monotonic_time'
         ActiveSupport::Notifications
       else
         NullInstrumenter

--- a/lib/racecar/instrumenter.rb
+++ b/lib/racecar/instrumenter.rb
@@ -11,6 +11,7 @@ module Racecar
       @default_payload = default_payload
 
       @backend = if defined?(ActiveSupport::Notifications)
+        # ActiveSupport needs `concurrent-ruby` but doesn't `require` it.
         require 'concurrent/utility/monotonic_time'
         ActiveSupport::Notifications
       else

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rdkafka",   "~> 0.8.0.beta.1"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "timecop"

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -6,34 +6,40 @@ RSpec.describe Racecar::Cli do
     Racecar.config = nil
   end
 
-  it "fails if no consumer class is specified" do
+  it "raise exception if no consumer class is specified" do
     expect { Racecar::Cli.main([]) }.to raise_exception(Racecar::Error, "no consumer specified")
   end
 
-  it "doesn't start Rails if --without-rails option is specified" do
-    args = ["--require", "./examples/cat_consumer.rb", "CatConsumer", "--without-rails"]
+  context "displaying startup message" do
+    before do
+      expect($stderr).to receive(:puts).with(/Starting Racecar consumer CatConsumer/)
+      expect($stderr).to receive(:puts).with(/Wro+m!/)
+      expect($stderr).to receive(:puts).with(/Ctrl-C to shutdown consumer/)
+    end
 
-    allow(Racecar).to receive(:run)
-    expect(Racecar::RailsConfigFileLoader).not_to receive(:load!)
+    it "doesn't start Rails if --without-rails option is specified" do
+      args = ["--require", "./examples/cat_consumer.rb", "CatConsumer", "--without-rails"]
 
-    Racecar::Cli.main(args)
-  end
+      allow(Racecar).to receive(:run)
+      expect(Racecar::RailsConfigFileLoader).not_to receive(:load!)
 
-  it "starts Rails if the --without-rails option is omitted" do
-    args = ["--require", "./examples/cat_consumer.rb", "CatConsumer"]
-
-    allow(Racecar).to receive(:run)
-    expect(Racecar::RailsConfigFileLoader).to receive(:load!)
-
-    Racecar::Cli.main(args)
-  end
-
-  it "outputs a helpful message and exits if the required library fails to load" do
-    args = ["--require", "./spec/support/bad_library.rb", "BadLibrary::BadConsumer"]
-    expected_output = "=> ./spec/support/bad_library.rb failed to load: BadLibrary failed to load\n"
-
-    expect {
       Racecar::Cli.main(args)
-    }.to raise_error(SystemExit).and output(expected_output).to_stderr
+    end
+
+    it "starts Rails if the --without-rails option is omitted" do
+      args = ["--require", "./examples/cat_consumer.rb", "CatConsumer"]
+
+      allow(Racecar).to receive(:run)
+      expect(Racecar::RailsConfigFileLoader).to receive(:load!)
+
+      Racecar::Cli.main(args)
+    end
+  end
+
+  it "raises an exception if the required library fails to load" do
+    args = ["--require", "./spec/support/bad_library.rb", "BadLibrary::BadConsumer"]
+    expect($stderr).to_not receive(:puts)
+
+    expect { Racecar::Cli.main(args) }.to raise_error(StandardError, "BadLibrary failed to load")
   end
 end

--- a/spec/exe/racecar_spec.rb
+++ b/spec/exe/racecar_spec.rb
@@ -26,8 +26,12 @@ RSpec.describe "exe/racecar" do
       ::ARGV = @orig_argv
     end
 
-    it "displays exception and exits with status 1" do
+    it "displays exception, calls exit_handler, and exits with failure status" do
       expect($stderr).to receive(:puts).with(/=> Crashed: LoadError: cannot load such file -- missing\n.*cli\.rb/)
+
+      expect(Racecar.config.error_handler).to receive(:call) do |e|
+        expect(e).to be_kind_of(LoadError)
+      end
 
       load "./exe/racecar"
 

--- a/spec/exe/racecar_spec.rb
+++ b/spec/exe/racecar_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "exe/racecar" do
     before do
       @orig_argv = ::ARGV
       Object.send(:remove_const, 'ARGV')
-      ::ARGV = ['--require', 'missing']
+      ::ARGV = ["--require", "./spec/support/bad_library.rb"]
     end
 
     after do
@@ -26,11 +26,12 @@ RSpec.describe "exe/racecar" do
       ::ARGV = @orig_argv
     end
 
-    it "displays exception, calls exit_handler, and exits with failure status" do
-      expect($stderr).to receive(:puts).with(/=> Crashed: LoadError: cannot load such file -- missing\n.*cli\.rb/)
+    it "displays exception with causes, calls exit_handler, and exits with failure status" do
+      expect($stderr).to receive(:puts).
+        with(/=> Crashed: StandardError: BadLibrary failed to load\n--- Caused by: ---\nArgumentError: may not be nil\n.*bad_library\.rb/)
 
       expect(Racecar.config.error_handler).to receive(:call) do |e|
-        expect(e).to be_kind_of(LoadError)
+        expect(e).to be_kind_of(StandardError)
       end
 
       load "./exe/racecar"

--- a/spec/exe/racecar_spec.rb
+++ b/spec/exe/racecar_spec.rb
@@ -1,0 +1,53 @@
+
+module Racecar
+  class << self
+    attr_accessor :exit_code
+
+    def exit(code = 0)
+      @exit_code = code
+    end
+  end
+end
+
+RSpec.describe "exe/racecar" do
+  before do
+    Racecar.exit_code = -1
+  end
+
+  context "when exception raised during startup" do
+    before do
+      @orig_argv = ::ARGV
+      Object.send(:remove_const, 'ARGV')
+      ::ARGV = ['--require', 'missing']
+    end
+
+    after do
+      Object.send(:remove_const, 'ARGV')
+      ::ARGV = @orig_argv
+    end
+
+    it "displays exception and exits with status 1" do
+      expect($stderr).to receive(:puts).with(/=> Crashed: LoadError: cannot load such file -- missing\n.*cli\.rb/)
+
+      load "./exe/racecar"
+
+      expect(Racecar.exit_code).to eq(1)
+    end
+  end
+
+  context "when SystemExit raised during startup" do
+    it "displays nothing and re-raises" do
+      expect($stderr).to_not receive(:puts)
+
+      SystemExit
+
+      expect(Racecar::Cli).to receive(:main).with(anything) { raise SystemExit }
+
+      expect do
+        load "./exe/racecar"
+      end.to raise_exception(SystemExit)
+
+      expect(Racecar.exit_code).to eq(-1)
+    end
+  end
+end

--- a/spec/support/bad_library.rb
+++ b/spec/support/bad_library.rb
@@ -1,3 +1,7 @@
 module BadLibrary
-  raise StandardError, "BadLibrary failed to load"
+  begin
+    raise ArgumentError, "may not be nil" # will appear as `cause` of exeception raised below
+  rescue
+    raise StandardError, "BadLibrary failed to load"
+  end
 end


### PR DESCRIPTION
- Added `spec/exe/racecar_spec`.
- Moved `rescue` out to `exe/racecar`.
- Added `"--- Caused by: ---\n"` when exception has cause(s).
- Note: moved `exe/racecar` code inside `Racecar.start` to make it possible to stub `exit` without affecting surrounding rspec when it calls `exit`.
- Added `require concurrent/utility/monotonic_time` because that test was failing due to the lack of that require on ActiveSupport 6.0.3.3.
- Moved `config` to `private`.
- Added `pry` as a development dependency.