### PR TITLE
add magic frozen_string_literal comment; avoid String#<< mutation of frozen strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in racecar.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/examples/batch_consumer.rb
+++ b/examples/batch_consumer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BatchConsumer < Racecar::Consumer
   subscribes_to "messages", start_from_beginning: false
 

--- a/examples/cat_consumer.rb
+++ b/examples/cat_consumer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CatConsumer < Racecar::Consumer
   subscribes_to "messages", start_from_beginning: false
 

--- a/examples/producing_consumer.rb
+++ b/examples/producing_consumer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ProducingConsumer < Racecar::Consumer
   subscribes_to "messages", start_from_beginning: false
 

--- a/lib/ensure_hash_compact.rb
+++ b/lib/ensure_hash_compact.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # only needed when ruby < 2.4 and not using active support
 
 unless {}.respond_to? :compact

--- a/lib/generators/racecar/consumer_generator.rb
+++ b/lib/generators/racecar/consumer_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   module Generators
     class ConsumerGenerator < Rails::Generators::NamedBase

--- a/lib/generators/racecar/install_generator.rb
+++ b/lib/generators/racecar/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   module Generators
     class InstallGenerator < Rails::Generators::Base

--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "logger"
 
 require "racecar/instrumenter"

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "optparse"
 require "logger"
 require "fileutils"
@@ -106,13 +108,13 @@ module Racecar
         end
 
         Racecar::Config.variables.each do |variable|
-          opt_name = "--" << variable.name.to_s.gsub("_", "-")
+          opt_name = +"--#{variable.name.to_s.gsub('_', '-')}"
           opt_name << " #{variable.type.upcase}" unless variable.boolean?
 
           desc = variable.description || "N/A"
 
           if variable.default
-            desc << " (default: #{variable.default.inspect})"
+            desc += " (default: #{variable.default.inspect})"
           end
 
           opts.on(opt_name, desc) do |value|

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "king_konf"
 
 module Racecar
@@ -196,8 +198,8 @@ module Racecar
         group_id_prefix,
 
         # MyFunnyConsumer => my-funny-consumer
-        consumer_class.name.gsub(/[a-z][A-Z]/) {|str| str[0] << "-" << str[1] }.downcase,
-      ].compact.join("")
+        consumer_class.name.gsub(/[a-z][A-Z]/) { |str| "#{str[0]}-#{str[1]}" }.downcase,
+      ].compact.join
 
       self.subscriptions = consumer_class.subscriptions
       self.max_wait_time = consumer_class.max_wait_time || self.max_wait_time

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   class Consumer
     Subscription = Struct.new(:topic, :start_from_beginning, :max_bytes_per_partition, :additional_config)

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   class ConsumerSet
     MAX_POLL_TRIES = 10

--- a/lib/racecar/ctl.rb
+++ b/lib/racecar/ctl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "optparse"
 require "racecar/rails_config_file_loader"
 require "racecar/daemon"

--- a/lib/racecar/daemon.rb
+++ b/lib/racecar/daemon.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   class Daemon
     attr_reader :pidfile

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "datadog/statsd"
 rescue LoadError

--- a/lib/racecar/instrumenter.rb
+++ b/lib/racecar/instrumenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   ##
   # Common API for instrumentation to standardize

--- a/lib/racecar/message.rb
+++ b/lib/racecar/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 
 module Racecar

--- a/lib/racecar/null_instrumenter.rb
+++ b/lib/racecar/null_instrumenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   # Ignores all instrumentation events.
   class NullInstrumenter

--- a/lib/racecar/pause.rb
+++ b/lib/racecar/pause.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   class Pause
     attr_reader :pauses_count

--- a/lib/racecar/rails_config_file_loader.rb
+++ b/lib/racecar/rails_config_file_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   module RailsConfigFileLoader
     def self.load!

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rdkafka"
 require "racecar/pause"
 require "racecar/message"

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   VERSION = "2.0.0"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "racecar/cli"
 
 RSpec.describe Racecar::Cli do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ostruct"
 require "racecar/config"
 

--- a/spec/consumer_set_spec.rb
+++ b/spec/consumer_set_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringio"
 
 def subscription(name)

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "racecar/datadog"
 RSpec.describe Racecar::Datadog::StatsdSubscriber do
   describe '#emit' do

--- a/spec/exe/racecar_spec.rb
+++ b/spec/exe/racecar_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Racecar
   class << self

--- a/spec/instrumenter_spec.rb
+++ b/spec/instrumenter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Racecar::Instrumenter do
   describe '#instrument' do
     let(:instrumenter) { Racecar::Instrumenter.new }

--- a/spec/integration/consumer_spec.rb
+++ b/spec/integration/consumer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "securerandom"
 require "racecar/cli"
 require "racecar/ctl"

--- a/spec/pause_spec.rb
+++ b/spec/pause_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ostruct"
 
 RSpec.describe Racecar::Pause do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringio"
 
 class TestConsumer < Racecar::Consumer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "racecar"
 require "timecop"

--- a/spec/support/bad_library.rb
+++ b/spec/support/bad_library.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BadLibrary
   begin
     raise ArgumentError, "may not be nil" # will appear as `cause` of exeception raised below

--- a/spec/support/mock_env.rb
+++ b/spec/support/mock_env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MockEnv
   def with_env(env_name, value)
     initial_state = ENV[env_name]


### PR DESCRIPTION
- add [magic frozen_string_literal comment](https://github.com/Invoca/magic_frozen_string_literal) at the top of each file
- avoid String#<< mutation of frozen strings by using `+` to make the string mutable, or `+=` to copy instead