### PR TITLE
Require racecar/version

### DIFF
--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -8,6 +8,7 @@ require "racecar/consumer"
 require "racecar/consumer_set"
 require "racecar/runner"
 require "racecar/config"
+require "racecar/version"
 require "ensure_hash_compact"
 
 module Racecar


### PR DESCRIPTION
Require `racecar/version` so we can easily check the currently running version of Racecar in the console.

Currently it doesn't work:

<img width="372" alt="image" src="https://user-images.githubusercontent.com/1541959/94675758-875d3e00-031a-11eb-83d8-f7f9e82df519.png">
