### PR TITLE
[Bugfix] Close RdKafka consumer in ConsumerSet#reset_current_consumer to prevent memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [Bugfix] Close RdKafka consumer in ConsumerSet#reset_current_consumer to prevent memory leak (#196)
+
 ## racecar v2.1.0
 
 * Bump rdkafka to 0.8.0 (#191)

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -142,7 +142,12 @@ module Racecar
     end
 
     def reset_current_consumer
-      @consumers[@consumer_id_iterator.peek] = nil
+      current_consumer_id = @consumer_id_iterator.peek
+      @logger.info "Resetting consumer with id: #{current_consumer_id}"
+
+      consumer = @consumers[current_consumer_id]
+      consumer.close unless consumer.nil?
+      @consumers[current_consumer_id] = nil
     end
 
     def maybe_select_next_consumer

--- a/spec/consumer_set_spec.rb
+++ b/spec/consumer_set_spec.rb
@@ -275,12 +275,13 @@ RSpec.describe Racecar::ConsumerSet do
       consumer_set.send(:select_next_consumer)
     end
 
-    it "#reset_current_consumer does what it says" do
+    it "#reset_current_consumer removes the reference to the Rdkafka consumer" do
       3.times do
         consumer_set.current
         consumer_set.send(:select_next_consumer)
       end
       consumer_set.send(:select_next_consumer)
+      allow(rdconsumer2).to receive(:close)
 
       expect do
         consumer_set.send(:reset_current_consumer)
@@ -289,12 +290,23 @@ RSpec.describe Racecar::ConsumerSet do
       }.from(rdconsumer2).to(nil)
     end
 
+    it "#reset_current_consumer closes the Rdkafka consumer" do
+      3.times do
+        consumer_set.current
+        consumer_set.send(:select_next_consumer)
+      end
+      consumer_set.send(:select_next_consumer)
+      expect(rdconsumer2).to receive(:close).once
+      consumer_set.send(:reset_current_consumer)
+    end
+
     it "#current recreates resetted consumers" do
       3.times do
         consumer_set.current
         consumer_set.send(:select_next_consumer)
       end
       consumer_set.send(:select_next_consumer)
+      allow(consumer_set.current).to receive(:close)
       consumer_set.send(:reset_current_consumer)
 
       expect(consumer_set.current).not_to be_nil


### PR DESCRIPTION
As described in https://github.com/zendesk/racecar/issues/194, this PR updates [Racecar::ConsumerSet#reset_current_consumer](https://github.com/zendesk/racecar/blob/d095104096ee62894a3d2bd47b11821f1b43abee/lib/racecar/consumer_set.rb#L144-L146)  so we [close](https://github.com/appsignal/rdkafka-ruby/blob/main/lib/rdkafka/consumer.rb#L22-L29) the underlying RdKafka consumer before removing iits reference in the `@consumers` array. Doing this prevents a memory leak when the broker disconnects from a consumers.

cc: @dasch 