### PR TITLE
Expose retries_count on Racecar::Message

### DIFF
--- a/lib/racecar/message.rb
+++ b/lib/racecar/message.rb
@@ -6,8 +6,11 @@ module Racecar
   class Message
     extend Forwardable
 
-    def initialize(rdkafka_message)
+    attr_reader :retries_count
+
+    def initialize(rdkafka_message, retries_count: nil)
       @rdkafka_message = rdkafka_message
+      @retries_count   = retries_count
     end
 
     def_delegators :@rdkafka_message, :topic, :partition, :offset, :key, :headers

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -390,9 +390,17 @@ RSpec.describe Racecar::Runner do
     it "keeps track of the number of retries when a message causes an exception" do
       error = StandardError.new("surprise")
 
-      [0, 1, 2, anything].each do |arg|
-        expect(config.error_handler).to receive(:call).at_least(:once).with(error, hash_including(retries_count: arg)).ordered
+      [0, 1, 2].each do |retries_count|
+        expect(config.error_handler).to receive(:call)
+          .once.with(error, hash_including(retries_count: retries_count)).ordered
+        expect(Racecar::Message).to receive(:new)
+          .once.with(anything, retries_count: retries_count).and_call_original
       end
+
+      expect(config.error_handler).to receive(:call)
+        .at_least(:once).with(error, hash_including(retries_count: anything))
+      expect(Racecar::Message).to receive(:new)
+        .at_least(:once).with(anything, retries_count: anything).and_call_original
 
       kafka.deliver_message(error, topic: "greetings")
 
@@ -514,9 +522,17 @@ RSpec.describe Racecar::Runner do
     it "keeps track of the number of retries when a message causes an exception" do
       error = StandardError.new("surprise")
 
-      [0, 1, 2, anything].each do |arg|
-        expect(config.error_handler).to receive(:call).at_least(:once).with(error, hash_including(retries_count: arg)).ordered
+      [0, 1, 2].each do |retries_count|
+        expect(config.error_handler).to receive(:call)
+          .once.with(error, hash_including(retries_count: retries_count)).ordered
+        expect(Racecar::Message).to receive(:new)
+          .once.with(anything, retries_count: retries_count).and_call_original
       end
+
+      expect(config.error_handler).to receive(:call)
+        .at_least(:once).with(error, hash_including(retries_count: anything))
+      expect(Racecar::Message).to receive(:new)
+        .at_least(:once).with(anything, retries_count: anything).and_call_original
 
       kafka.deliver_message(error, topic: "greetings")
 


### PR DESCRIPTION
In a recent [PR](https://github.com/zendesk/racecar/pull/187), support was added to provide `retries_count` to the instrumentation payload, in order to define custom behaviours on error handling. However, this does not allow us to drive the consumer's behaviour based on the retries, if required.

Example usage:
- We're consuming from a topic where we don't absolutely need to process every single update successfully, however we want to allow for a few intermittent failures
```
class SemiImportantConsumer < Racecar::Consumer
  MAX_RETRIES_COUNT = 5

  subscribes_to "semi_important_topic"

  def process(message)
    data = JSON.parse(message.value)

    do_some_stuff(data)
  rescue StandardError => e
    raise e if message.retries_count < MAX_RETRIES_COUNT

    Honeybadger.notify(e)
    Logger.error("Oh no we ran out of retries")
    ... etc
  end
end
```