### PR TITLE
Update king_konf runtime dependency to version 1.0

### DIFF
--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "king_konf", "~> 0.3.7"
+  spec.add_runtime_dependency "king_konf", "~> 1.0.0"
   spec.add_runtime_dependency "rdkafka",   "~> 0.8.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]


### PR DESCRIPTION
Taking into a look into the last commits of `king_konf` gem, it shouldn't be a problem updating this runtime dependency in racecar, so, this PR updates it to version 1.0