### PR TITLE
Handle ERR_NOT_COORDINATOR

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    racecar (2.3.0.alpha1)
+    racecar (2.3.0)
       king_konf (~> 1.0.0)
       rdkafka (~> 0.8.0)
 
@@ -18,12 +18,12 @@ GEM
     concurrent-ruby (1.1.7)
     diff-lcs (1.4.4)
     dogstatsd-ruby (4.8.2)
-    ffi (1.15.0)
+    ffi (1.15.3)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     king_konf (1.0.0)
     method_source (1.0.0)
-    mini_portile2 (2.5.1)
+    mini_portile2 (2.6.1)
     minitest (5.14.2)
     pry (0.13.1)
       coderay (~> 1.1)

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -156,7 +156,7 @@ module Racecar
       msg = current.poll(max_wait_time_ms)
     rescue Rdkafka::RdkafkaError => e
       case e.code
-      when :max_poll_exceeded, :transport # -147, -195
+      when :max_poll_exceeded, :transport, :not_coordinator # -147, -195, 16
         reset_current_consumer
       end
       raise


### PR DESCRIPTION
Whenever a "Not Coordinator for group" error gets thrown the consumers
get stuck and they never recover. We should be retrying once that
happens.