### PR TITLE
Better CI bundle cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,7 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
     - name: Build and test with RSpec
-      run: |
-        bundle install --jobs 4 --retry 3
-        bundle exec rspec --format documentation --require spec_helper --color --exclude-pattern='spec/integration/*_spec.rb'
+      run: bundle exec rspec --format documentation --require spec_helper --color --exclude-pattern='spec/integration/*_spec.rb'
 
   integration-specs:
     runs-on: ubuntu-latest
@@ -57,6 +55,4 @@ jobs:
     - name: Build and test with RSpec
       env:
         RACECAR_BROKERS: localhost:9092
-      run: |
-        bundle install --jobs 4 --retry 3
-        bundle exec rspec --format documentation --require spec_helper --color spec/integration/*_spec.rb
+      run: bundle exec rspec --format documentation --require spec_helper --color spec/integration/*_spec.rb

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,69 @@
+PATH
+  remote: .
+  specs:
+    racecar (2.1.1)
+      king_konf (~> 1.0.0)
+      rdkafka (~> 0.8.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.3.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.7)
+    diff-lcs (1.4.4)
+    dogstatsd-ruby (4.8.2)
+    ffi (1.13.1)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
+    king_konf (1.0.0)
+    method_source (1.0.0)
+    mini_portile2 (2.5.0)
+    minitest (5.14.2)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (13.0.1)
+    rdkafka (0.8.1)
+      ffi (~> 1.9)
+      mini_portile2 (~> 2.1)
+      rake (>= 12.3)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.0)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.0)
+    thread_safe (0.3.6)
+    timecop (0.9.2)
+    tzinfo (1.2.8)
+      thread_safe (~> 0.1)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (>= 4.0, < 6.1)
+  bundler (>= 1.13, < 3)
+  dogstatsd-ruby (>= 4.0.0, < 5.0.0)
+  pry
+  racecar!
+  rake (> 10.0)
+  rspec (~> 3.0)
+  timecop
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
By adding Gemfile.lock to the repository, and `bundler-cache: true` is set in the CI configuration, the `zendesk/setup-ruby` action will take care of installing the gems too. 

Please notice the speed difference in [latest master build](https://github.com/zendesk/racecar/actions/runs/426507907) and [this PR build](https://github.com/zendesk/racecar/actions/runs/426775450).

If checking in Gemfile.lock is a concern – e.g. do we forget to test for newer versions of our dependencies – we might want to let [Dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically) keep Gemfile.lock updated?