### PR TITLE
set correct default values for max_wait_time on poll and batch_poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [Racecar::ConsumerSet] **breaking change** `Racecar::ConsumerSet`'s functions `poll` and `batch_pall` expect the max wait values to be given in milliseconds. The defaults were using `config.max_wait_time`, which is in seconds. If you do not directly use `Racecar::ConsumerSet`, or always call its `poll` and `batch_poll` functions by specfiying the max wait time (the first argument), then this breaking change does not affect you. ([#214](https://github.com/zendesk/racecar/pull/214))
+
 ## racecar v2.1.1
 
 * [Bugfix] Close RdKafka consumer in ConsumerSet#reset_current_consumer to prevent memory leak (#196)

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -54,7 +54,7 @@ module Racecar
     desc "How long to wait when trying to communicate with a Kafka broker"
     float :socket_timeout, default: 30
 
-    desc "How long to allow the Kafka brokers to wait before returning messages"
+    desc "How long to allow the Kafka brokers to wait before returning messages (in seconds)"
     float :max_wait_time, default: 1
 
     desc "Maximum amount of data the broker shall return for a Fetch request"

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -17,7 +17,7 @@ module Racecar
       @last_poll_read_nil_message = false
     end
 
-    def poll(max_wait_time_ms = @config.max_wait_time)
+    def poll(max_wait_time_ms = @config.max_wait_time_ms)
       batch_poll(max_wait_time_ms, 1).first
     end
 
@@ -31,7 +31,7 @@ module Racecar
     # Any errors during polling are retried in an exponential backoff fashion. If an error
     # occurs, but there is no time left for a backoff and retry, it will return the
     # already collected messages and only retry on the next call.
-    def batch_poll(max_wait_time_ms = @config.max_wait_time, max_messages = @config.fetch_messages)
+    def batch_poll(max_wait_time_ms = @config.max_wait_time_ms, max_messages = @config.fetch_messages)
       started_at = Time.now
       remain_ms = max_wait_time_ms
       maybe_select_next_consumer


### PR DESCRIPTION
If the higher level runner Racecar::Runner was used, this makes no
difference, as it already passes the correct @config.max_wait_time_ms
value. If someone uses ConsumerSet directly, without specifying
these values, this will be a breaking change.