### PR TITLE
silence error about no time left when there were no errors

### DIFF
--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -130,6 +130,9 @@ module Racecar
         @logger.debug "Capping #{wait_ms}ms to #{max_wait_time_ms-1}ms."
         sleep (max_wait_time_ms-1)/1000.0
         remain_ms = 1
+      elsif try == 0 && remain_ms == 0
+        @logger.debug "No time remains for polling messages. Will try on next call."
+        return nil
       elsif wait_ms >= remain_ms
         @logger.error "Only #{remain_ms}ms left, but want to wait for #{wait_ms}ms before poll. Will retry on next call."
         @previous_retries = try

--- a/spec/consumer_set_spec.rb
+++ b/spec/consumer_set_spec.rb
@@ -190,6 +190,17 @@ RSpec.describe Racecar::ConsumerSet do
           end
         end
 
+        it "does not report errors for zero time remain edge cases" do
+          Timecop.freeze do
+            allow(logger).to receive(:error)
+            allow(consumer_set).to receive(:remaining_time_ms).and_return(0)
+
+            consumer_set.batch_poll(150)
+
+            expect(logger).not_to have_received(:error)
+          end
+        end
+
         it "forwards to Rdkafka (as poll)" do
           config.fetch_messages = 3
           expect(rdconsumer).to receive(:poll).exactly(3).times.with(100).and_return(:msg1, :msg2, :msg3)


### PR DESCRIPTION
This occurs when there is only little time left and the remain_ms
works itself out to 0ms. The error message given in this scenario
before this patch is unhelpful or misleading, and doesn't need to
be acted upon most of the time. The edge case where it matters is
if remain_ms is always 0, e.g. if the system is too slow for the
configured max_wait_time_ms. Hence the debug message to see this
more easily, though it is expected that this shows up on healthy
and properly configured systems, too.

Related to https://github.com/zendesk/racecar/pull/204 . This PR
should make the error much less likely to appear in the first place.
The test included in this PR will fail if the other PR is merged,
because it checks using the log level of the error message (it's an
easy fix, though).