### PR TITLE
Fix ssl_verify_hostname

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -231,6 +231,7 @@ module Racecar
     def rdkafka_security_config
       {
         "security.protocol" => security_protocol,
+        "enable.ssl.certificate.verification" => ssl_verify_hostname,
         "ssl.ca.location" => ssl_ca_location,
         "ssl.crl.location" => ssl_crl_location,
         "ssl.keystore.location" => ssl_keystore_location,


### PR DESCRIPTION
Fix ssl_verify_hostname which was broken since the change to rdkafka.