### PR TITLE
Concurrency testing using a forking approach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Build and test with RSpec
       env:
         RACECAR_BROKERS: localhost:9092
-      run: bundle exec rspec --format documentation --require spec_helper --color spec/integration/*_spec.rb
+      run: timeout --kill-after 120 90 bundle exec rspec --format documentation --require spec_helper --color spec/integration/*_spec.rb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Build and test with RSpec
       env:
         RACECAR_BROKERS: localhost:9092
-      run: timeout --kill-after 120 90 bundle exec rspec --format documentation --require spec_helper --color spec/integration/*_spec.rb
+      run: timeout --kill-after 180 150 bundle exec rspec --format documentation --require spec_helper --color spec/integration/*_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add Ruby 3.0 compatibility (#237)
 * Introduce parallel runner, which forks a number of independent consumers, allowing partitions to be processed in parallel. ([#222](https://github.com/zendesk/racecar/pull/222))
 * [Racecar::Runner] Ensure producer is closed, whether it closes or errors. ([#222](https://github.com/zendesk/racecar/pull/222))
+* Configure `statistics_interval` directly in the config. Disable statistics when no callback is defined ([#232](https://github.com/zendesk/racecar/pull/232))
 
 ## racecar v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [Racecar::Consumer] When message delivery times out, Racecar will reset the producer in an attempt to fix some of the potential causes for this error. ([#219](https://github.com/zendesk/racecar/pull/219))
 * Validate the `process` and `process_batch` method signature on consumer classes when initializing (#236)
 * Add Ruby 3.0 compatibility (#237)
+* Introduce parallel runner, which forks a number of independent consumers, allowing partitions to be processed in parallel. ([#222](https://github.com/zendesk/racecar/pull/222))
+* [Racecar::Runner] Ensure producer is closed, whether it closes or errors. ([#222](https://github.com/zendesk/racecar/pull/222))
 
 ## racecar v2.2.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM circleci/ruby:2.7.2
+
+RUN sudo apt-get update
+RUN sudo apt-get install docker
+
+WORKDIR /app
+COPY . .
+
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -520,6 +520,16 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 The integration tests run against a Kafka instance that is not automatically started from within `rspec`. You can set one up using the provided `docker-compose.yml` by running `docker-compose up`.
 
+### Running RSpec within Docker
+
+There can be behavioural inconsistencies between running the specs on your machine, and in the CI pipeline. Due to this, there is now a Dockerfile included in the project, which is based on the CircleCI ruby 2.7.2 image. This could easily be extended with more Dockerfiles to cover different Ruby versions if desired. In order to run the specs via Docker:
+
+- Uncomment the `tests` service from the docker-compose.yml
+- Bring up the stack with `docker-compose up -d`
+- Execute the entire suite with `docker-compose run --rm tests rspec`
+- Execute a single spec or directory with `docker-compose run --rm tests rspec spec/integration/consumer_spec.rb`
+
+Please note - your code directory is mounted as a volume, so you can make code changes without needing to rebuild
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ If you want to process different partitions in parallel, and don't want to deplo
 The number of parallel workers is configured per consumer class; you may only want to take advantage of this for busier consumers:
 ```ruby
 class ParallelProcessingConsumer < Racecar::Consumer
-  subscribes_to "some-topic", parallel_workers: 5
+  subscribes_to "some-topic"
+
+  self.parallel_workers = 5
 
   def process(message)
     ...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
 version: '2.1'
+
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.1
-    hostname: zookeeper
-    container_name: zookeeper
     ports:
       - "2181:2181"
     environment:
@@ -15,8 +14,6 @@ services:
 
   broker:
     image: confluentinc/cp-kafka:5.5.1
-    hostname: broker
-    container_name: broker
     depends_on:
       - zookeeper
     ports:
@@ -44,3 +41,25 @@ services:
         condition: service_healthy
       zookeeper:
         condition: service_healthy
+
+
+  # If you want to run the tests locally with Docker, comment in the tests service.
+  # The behaviour, especially of the integration tests, can differ somewhat compared
+  # to running it on your machine.
+
+  # tests:
+  #   build:
+  #     context: .
+  #   depends_on:
+  #     wait-for-healthy-services:
+  #       condition: service_started
+  #   environment:
+  #     RACECAR_BROKERS: broker:29092
+  #     DOCKER_SUDO: 'true'
+  #   # When bringing up the stack, we just let the container exit. For running the
+  #   # specs, we'll use commands like `docker-compose run tests rspec`
+  #   command: ["echo", "ready"]
+  #   volumes:
+  #     # The line below allows us to run docker commands from the container itself
+  #     - "/var/run/docker.sock:/var/run/docker.sock"
+  #     - .:/app

--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -7,6 +7,7 @@ require "racecar/null_instrumenter"
 require "racecar/consumer"
 require "racecar/consumer_set"
 require "racecar/runner"
+require "racecar/parallel_runner"
 require "racecar/config"
 require "racecar/version"
 require "ensure_hash_compact"
@@ -51,6 +52,12 @@ module Racecar
   end
 
   def self.run(processor)
-    Runner.new(processor, config: config, logger: logger, instrumenter: instrumenter).run
+    runner = Runner.new(processor, config: config, logger: logger, instrumenter: instrumenter)
+
+    if config.parallel_workers && config.parallel_workers > 1
+      ParallelRunner.new(runner: runner, config: config, logger: logger).run
+    else
+      runner.run
+    end
   end
 end

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -59,8 +59,8 @@ module Racecar
       end
 
       processor = consumer_class.new
-
       Racecar.run(processor)
+      nil
     end
 
     private

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -167,7 +167,7 @@ module Racecar
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 
-    attr_accessor :subscriptions, :logger
+    attr_accessor :subscriptions, :logger, :parallel_workers
 
     def statistics_interval_ms
       if Rdkafka::Config.statistics_callback
@@ -220,6 +220,7 @@ module Racecar
         consumer_class.name.gsub(/[a-z][A-Z]/) { |str| "#{str[0]}-#{str[1]}" }.downcase,
       ].compact.join
 
+      self.parallel_workers = consumer_class.parallel_workers
       self.subscriptions = consumer_class.subscriptions
       self.max_wait_time = consumer_class.max_wait_time || self.max_wait_time
       self.pidfile ||= "#{group_id}.pid"

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -9,7 +9,7 @@ module Racecar
     class << self
       attr_accessor :max_wait_time
       attr_accessor :group_id
-      attr_accessor :producer, :consumer
+      attr_accessor :producer, :consumer, :parallel_workers
 
       def subscriptions
         @subscriptions ||= []
@@ -27,7 +27,15 @@ module Racecar
       # @param additional_config [Hash] Configuration properties for consumer.
       #   See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
       # @return [nil]
-      def subscribes_to(*topics, start_from_beginning: true, max_bytes_per_partition: 1048576, additional_config: {})
+      def subscribes_to(
+        *topics,
+        start_from_beginning: true,
+        max_bytes_per_partition: 1048576,
+        additional_config: {},
+        parallel_workers: nil
+      )
+        self.parallel_workers = parallel_workers
+
         topics.each do |topic|
           subscriptions << Subscription.new(topic, start_from_beginning, max_bytes_per_partition, additional_config)
         end

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -31,11 +31,8 @@ module Racecar
         *topics,
         start_from_beginning: true,
         max_bytes_per_partition: 1048576,
-        additional_config: {},
-        parallel_workers: nil
+        additional_config: {}
       )
-        self.parallel_workers = parallel_workers
-
         topics.each do |topic|
           subscriptions << Subscription.new(topic, start_from_beginning, max_bytes_per_partition, additional_config)
         end

--- a/lib/racecar/parallel_runner.rb
+++ b/lib/racecar/parallel_runner.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Racecar
+  class ParallelRunner
+    Worker = Struct.new(:pid, :parent_reader)
+
+    SHUTDOWN_SIGNALS = ["INT", "QUIT", "TERM"]
+
+    def initialize(runner:, config:, logger:)
+      @runner = runner
+      @config = config
+      @logger = logger
+    end
+
+    def worker_pids
+      workers.map(&:pid)
+    end
+
+    def running?
+      @running
+    end
+
+    def run
+      logger.info "=> Running with #{config.parallel_workers} parallel workers"
+
+      self.workers = config.parallel_workers.times.map do
+        run_worker.tap { |w| logger.info "=> Forked new Racecar consumer with process id #{w.pid}" }
+      end
+
+      # Print the consumer config to STDERR on USR1.
+      trap("USR1") { $stderr.puts config.inspect }
+
+      SHUTDOWN_SIGNALS.each { |signal| trap(signal) { terminate_workers } }
+
+      @running = true
+
+      wait_for_exit
+    end
+
+    private
+
+    attr_accessor :workers
+    attr_reader :runner, :config, :logger
+
+    def run_worker
+      parent_reader, child_writer = IO.pipe
+
+      pid = fork do
+        begin
+          parent_reader.close
+
+          runner.run
+        rescue Exception => e
+          # Allow the parent process to re-raise the exception after shutdown
+          child_writer.binmode
+          child_writer.write(Marshal.dump(e))
+        ensure
+          child_writer.close
+        end
+      end
+
+      child_writer.close
+
+      Worker.new(pid, parent_reader)
+    end
+
+    def terminate_workers
+      return if @terminating
+
+      @terminating = true
+      $stderr.puts "=> Terminating workers"
+
+      Process.kill("TERM", *workers.map(&:pid))
+    end
+
+    def wait_for_exit
+      # The call to IO.select blocks until one or more of our readers are ready for reading,
+      # which could be for one of two reasons:
+      #
+      # - An exception is raised in the child process, in which case we should initiate
+      #   a shutdown;
+      #
+      # - A graceful shutdown was already initiated, and the pipe writer has been closed, in
+      #   which case there is nothing more to do.
+      #
+      # - One of the child processes was killed somehow. If this turns out to be too strict
+      #   (i.e. closing down all the workers, we could revisit and look at restarting dead
+      #   workers.
+      #
+      ready_readers = IO.select(workers.map(&:parent_reader)).first
+
+      first_read = ready_readers.first.read
+
+      terminate_workers
+
+      workers.map(&:pid).each do |pid|
+        $stderr.puts "=> Waiting for worker with pid #{pid} to exit"
+        Process.waitpid(pid)
+        $stderr.puts "=> Worker with pid #{pid} shutdown"
+      end
+
+      exception_found = !first_read.empty?
+      raise Marshal.load(first_read) if exception_found
+    end
+  end
+end

--- a/lib/racecar/parallel_runner.rb
+++ b/lib/racecar/parallel_runner.rb
@@ -94,9 +94,9 @@ module Racecar
       terminate_workers
 
       workers.map(&:pid).each do |pid|
-        $stderr.puts "=> Waiting for worker with pid #{pid} to exit"
+        logger.debug "=> Waiting for worker with pid #{pid} to exit"
         Process.waitpid(pid)
-        $stderr.puts "=> Worker with pid #{pid} shutdown"
+        logger.debug "=> Worker with pid #{pid} shutdown"
       end
 
       exception_found = !first_read.empty?

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -90,6 +90,8 @@ module Racecar
           consumer.close
         end
       end
+    ensure
+      producer.close
     end
 
     def stop

--- a/spec/integration/consumer_spec.rb
+++ b/spec/integration/consumer_spec.rb
@@ -74,8 +74,9 @@ RSpec.describe "running a Racecar consumer", type: :integration do
     before do
       create_topic(topic: input_topic, partitions: topic_partitions)
 
-      consumer_class.subscribes_to(input_topic, parallel_workers: parallelism)
+      consumer_class.subscribes_to(input_topic)
       consumer_class.output_topic = output_topic
+      consumer_class.parallel_workers = parallelism
 
       publish_messages!(input_topic, input_messages)
     end

--- a/spec/integration/consumer_spec.rb
+++ b/spec/integration/consumer_spec.rb
@@ -14,7 +14,9 @@ end
 
 RSpec.describe "running a Racecar consumer", type: :integration do
   context "when an error occurs trying to start the runner" do
-    context "when there are no subscriptions" do
+    context "when there are no subscriptions, and no parallelism" do
+      before { NoSubsConsumer.parallel_workers = nil }
+
       it "raises an exception" do
         expect do
           Racecar::Cli.new(["NoSubsConsumer"]).run
@@ -22,7 +24,29 @@ RSpec.describe "running a Racecar consumer", type: :integration do
       end
     end
 
-    context "when there is no process method" do
+    context "when there are no subscriptions, and parallelism" do
+      before { NoSubsConsumer.parallel_workers = 3 }
+
+      it "raises an exception" do
+        expect do
+          Racecar::Cli.new(["NoSubsConsumer"]).run
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when there is no process method, and no parallelism" do
+      before { NoProcessConsumer.parallel_workers = nil }
+
+      it "raises an exception" do
+        expect do
+          Racecar::Cli.new(["NoProcessConsumer"]).run
+        end.to raise_error(NotImplementedError)
+      end
+    end
+
+    context "when there is no process method, and parallelism" do
+      before { NoSubsConsumer.parallel_workers = 3 }
+
       it "raises an exception" do
         expect do
           Racecar::Cli.new(["NoProcessConsumer"]).run
@@ -47,28 +71,14 @@ RSpec.describe "running a Racecar consumer", type: :integration do
       end
     end
 
-    let(:run_in_background!) do
-      Thread.new do
-        @runner_pid = Process.pid
-        Thread.current.abort_on_exception = true
-        Racecar::Cli.new([consumer_class.name.to_s]).run
-      end
-    end
-
     before do
       create_topic(topic: input_topic, partitions: topic_partitions)
 
-      consumer_class.subscribes_to(input_topic)
+      consumer_class.subscribes_to(input_topic, parallel_workers: parallelism)
       consumer_class.output_topic = output_topic
 
-      rdkafka_consumer.subscribe(output_topic)
-
       publish_messages!(input_topic, input_messages)
-
-      run_in_background!
     end
-
-    after { Process.kill("INT", @runner_pid) }
 
     after(:all) { delete_all_test_topics }
 
@@ -79,12 +89,17 @@ RSpec.describe "running a Racecar consumer", type: :integration do
         end
         EchoConsumer1
       end
+
       let(:input_messages) { [{ payload: "hello", key: "greetings", partition: nil }] }
       let(:topic_partitions) { 1 }
-      let(:concurrency) { 1 }
+      let(:parallelism) { nil }
 
       it "can consume and publish a message" do
-        wait_for_messages(topic: input_topic, expected_message_count: 1)
+        in_background(cleanup_callback: -> { Process.kill("INT", Process.pid) }) do
+          wait_for_messages(topic: output_topic, expected_message_count: 1)
+        end
+
+        Racecar::Cli.new([consumer_class.name.to_s]).run
 
         message = incoming_messages.first
 
@@ -92,6 +107,87 @@ RSpec.describe "running a Racecar consumer", type: :integration do
         expect(message.topic).to eq output_topic
         expect(message.payload).to eq "hello"
         expect(message.key).to eq "greetings"
+      end
+    end
+
+    context "when running parallel workers" do
+      let(:input_messages) do
+        [
+          { payload: "message-0", partition: 0, key: "a" },
+          { payload: "message-1", partition: 1, key: "a" },
+          { payload: "message-2", partition: 2, key: "a" },
+          { payload: "message-3", partition: 3, key: "a" },
+          { payload: "message-4", partition: 4, key: "a" },
+          { payload: "message-5", partition: 5, key: "a" }
+        ]
+      end
+
+      context "when partitions exceed parallelism" do
+        let(:topic_partitions) { 6 }
+        let(:parallelism) { 3 }
+        let(:consumer_class) do
+          class EchoConsumer2 < mock_echo_consumer_class
+            self.group_id = "echo-consumer-2"
+          end
+          EchoConsumer2
+        end
+
+        it "assigns partitions to all parallel workers" do
+          in_background(cleanup_callback: -> { Process.kill("INT", Process.pid) }) do
+            wait_for_assignments(
+              group_id: "echo-consumer-2",
+              topic: input_topic,
+              expected_members_count: parallelism
+            )
+            wait_for_messages(topic: output_topic, expected_message_count: input_messages.count)
+          end
+
+          Racecar::Cli.new([consumer_class.name.to_s]).run
+
+          expect(incoming_messages.map(&:topic).uniq).to eq([output_topic])
+          expect(incoming_messages.map(&:payload))
+            .to match_array(input_messages.map { |m| m[:payload] })
+        end
+      end
+
+      context "when the parallelism exceeds the number of partitions" do
+        let(:consumer_class) do
+          class EchoConsumer3 < mock_echo_consumer_class
+            self.group_id = "echo-consumer-3"
+          end
+          EchoConsumer3
+        end
+
+        let(:topic_partitions) { 3 }
+        let(:parallelism) { 5 }
+        let(:input_messages) do
+          [
+            { payload: "message-0", partition: 0, key: "a" },
+            { payload: "message-1", partition: 0, key: "a" },
+            { payload: "message-2", partition: 1, key: "a" },
+            { payload: "message-3", partition: 1, key: "a" },
+            { payload: "message-4", partition: 2, key: "a" },
+            { payload: "message-5", partition: 2, key: "a" }
+          ]
+        end
+
+        it "assigns all the consumers that it can, up to the total number of partitions" do
+          in_background(cleanup_callback: -> { Process.kill("INT", Process.pid) }) do
+            wait_for_assignments(
+              group_id: "echo-consumer-3",
+              topic: input_topic,
+              expected_members_count: topic_partitions
+            )
+            wait_for_messages(topic: output_topic, expected_message_count: input_messages.count)
+          end
+
+          Racecar::Cli.new([consumer_class.name.to_s]).run
+
+          expect(incoming_messages.count).to eq(6)
+          expect(incoming_messages.map(&:topic).uniq).to eq([output_topic])
+          expect(incoming_messages.map(&:payload))
+            .to match_array(input_messages.map { |m| m[:payload] })
+        end
       end
     end
   end

--- a/spec/parallel_runner_spec.rb
+++ b/spec/parallel_runner_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "racecar/parallel_runner"
+
+CustomError = Class.new(StandardError)
+
+RSpec.describe Racecar::ParallelRunner do
+  let(:config) { double(:config, parallel_workers: parallel_workers) }
+  let(:parallel_workers) { 3 }
+  let(:parallel_runner) { described_class.new(runner: runner, config: config, logger: Racecar.logger) }
+  let(:encoding) { Encoding.default_internal }
+
+  def when_ready(&block)
+    attempts = 0
+    sleep_duration = 0.1
+
+    Thread.new do
+      Thread.current.abort_on_exception = true
+      until parallel_runner.running?
+        raise "Runner was not running after #{attempts} attempts" if attempts >= 10
+
+        sleep sleep_duration
+        attempts += 1
+      end
+      block.call
+    end
+  end
+
+  before do
+    @previous_internal = Encoding.default_internal
+    Encoding.default_internal = encoding
+  end
+
+  after do
+    Encoding.default_internal = @previous_internal
+  end
+
+  describe "#run" do
+    context "when all of the workers raise an error" do
+      let(:parallel_workers) { 1 }
+
+      let(:runner_class) do
+        Class.new do
+          def run
+            raise CustomError, "Kaboom!"
+          end
+        end
+      end
+      let(:runner) { runner_class.new }
+
+      context "when default encoding is not set" do
+        let(:encoding) { nil }
+
+        it "raises the error from the worker and shuts down" do
+          expect { parallel_runner.run }.to raise_error(CustomError) do |e|
+            expect(e.message).to eq "Kaboom!"
+          end
+        end
+      end
+
+      context "when default encoding is set to UTF-8" do
+        let(:encoding) { Encoding::UTF_8 }
+
+        it "raises the error from the worker and shuts down" do
+          expect { parallel_runner.run }.to raise_error(CustomError) do |e|
+            expect(e.message).to eq "Kaboom!"
+          end
+        end
+      end
+    end
+
+    context "when one of the workers raises an error" do
+      let(:runner_class) do
+        Class.new do
+          def run
+            trap("TERM") { @stop = true }
+            trap("INT") { @explode = true }
+
+            loop do
+              break if @stop
+              raise CustomError, "Kaboom!" if @explode
+              sleep 0.1
+            end
+          end
+        end
+      end
+      let(:runner) { runner_class.new }
+
+      context "when default encoding is not set" do
+        let(:encoding) { nil }
+
+        it "raises the error from the worker and shuts down" do
+          when_ready do
+            Process.kill("INT", parallel_runner.worker_pids.first)
+          end
+
+          expect { parallel_runner.run }.to raise_error(CustomError) do |e|
+            expect(e.message).to eq "Kaboom!"
+          end
+        end
+      end
+
+      context "when default encoding is set to UTF-8" do
+        let(:encoding) { Encoding::UTF_8 }
+
+        it "raises the error from the worker and shuts down" do
+          when_ready do
+            Process.kill("INT", parallel_runner.worker_pids.first)
+          end
+
+          expect { parallel_runner.run }.to raise_error(CustomError) do |e|
+            expect(e.message).to eq "Kaboom!"
+          end
+        end
+      end
+    end
+
+    context "when one of the workers is sent a shutdown signal after successful boot" do
+      let(:runner_class) do
+        Class.new do
+          def run
+            trap("TERM") { @stop = true }
+
+            loop do
+              sleep 0.1
+              break if @stop
+            end
+          end
+        end
+      end
+
+      let(:runner) { runner_class.new }
+
+      it "stops all the child processes and closes gracefully" do
+        when_ready do
+          Process.kill("TERM", parallel_runner.worker_pids.first)
+        end
+
+        expect { parallel_runner.run }.not_to raise_error
+      end
+    end
+
+    context "when the parent process is sent a shutdown signal after successful boot" do
+      let(:runner_class) do
+        Class.new do
+          def run
+            trap("TERM") { @stop = true }
+
+            loop do
+              sleep 0.1
+              break if @stop
+            end
+          end
+        end
+      end
+
+      let(:runner) { runner_class.new }
+
+      it "stops all the child processes and closes gracefully" do
+        when_ready do
+          Process.kill("TERM", Process.pid)
+        end
+
+        expect { parallel_runner.run }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -48,10 +48,10 @@ module IntegrationHelper
 
     attempts = 0
 
-    while incoming_messages.count < expected_message_count &&
-        attempts < 20
+    while incoming_messages.count < expected_message_count && attempts < 20
       $stderr.puts "Waiting for messages..."
-      if (message = rdkafka_consumer.poll(1000))
+
+      while (message = rdkafka_consumer.poll(1000))
         $stderr.puts "Received message #{message}"
         incoming_messages << message
       end
@@ -140,6 +140,10 @@ module IntegrationHelper
   end
 
   def run_kafka_command(command)
-    Open3.capture2e("docker exec -t $(docker ps | grep broker | awk '{print $1}') #{command}")
+    maybe_sudo = "sudo " if ENV["DOCKER_SUDO"] == "true"
+
+    Open3.capture2e(
+      "#{maybe_sudo}docker exec -t $(#{maybe_sudo}docker ps | grep broker | awk '{print $1}') #{command}"
+    )
   end
 end


### PR DESCRIPTION
The issue: https://github.com/zendesk/racecar/issues/188

Some discussion on a previous implementation approach on this PR: https://github.com/zendesk/racecar/pull/221 - this PR is an initial draft to continue the conversation.

Adds a `ConcurrentRunner`, which uses forking to allow concurrent processing:
- Adds the code in a way that does not affect existing APIs (you never know what your users will decide to depend on)
- Includes quite a big overhaul of the existing integration test so that we have a fresh topic for each spec, and we also clean up the topics at the end.

What hasn't been done yet?
- Extensive testing
- Some kind of benchmarking in a semi-realistic setup. Few possible scenarios:
  - Consuming a pile of messages and writing one straight out again
  - Consuming a pile of messages and syncing it into a database

Outstanding question(s):
- Should there be a hard limit on max concurrency?