### PR TITLE
Add Prometheus client integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,9 +25,11 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.0)
     minitest (5.14.2)
+    prometheus-client (2.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    rack (2.2.3)
     rake (13.0.1)
     rdkafka (0.8.1)
       ffi (~> 1.9)
@@ -59,8 +61,10 @@ DEPENDENCIES
   activesupport (>= 4.0, < 6.1)
   bundler (>= 1.13, < 3)
   dogstatsd-ruby (>= 4.0.0, < 5.0.0)
+  prometheus-client (>= 2.1.0)
   pry
   racecar!
+  rack
   rake (> 10.0)
   rspec (~> 3.0)
   timecop

--- a/README.md
+++ b/README.md
@@ -320,6 +320,17 @@ Racecar supports [Datadog](https://www.datadoghq.com/) monitoring integration. I
 * `datadog_namespace` – The namespace to use for Datadog metrics.
 * `datadog_tags` – Tags that should always be set on Datadog metrics.
 
+#### Prometheus monitoring
+
+Racecar supports [Prometheus](https://www.prometheus.io/) monitoring integration. If you are scraping data from other applications, you just need to set `prometheus_enabled` to `true` and have `prometheus-client` gem on your dependencies, as the rest of the settings come with sane defaults.
+
+* `prometheus_enabled` – Whether prometheus monitoring is enabled (defaults to `false`) or not.
+* `prometheus_endpoint` – The server metrics endpoint that is used to fetch prometheus data.
+* `prometheus_registry` – The prometheus client instance.
+* `prometheus_port` – The port use on the server.
+
+After prometheus is enabled, you could instrument your consumers or listen the racecar events with a subscriber as it is in the following [example](examples/racecar_subscriber.rb).
+
 #### Consumers Without Rails ####
 
 By default, if Rails is detected, it will be automatically started when the consumer is started. There are cases where you might not want or need Rails. You can pass the `--without-rails` option when starting the consumer and Rails won't be started.

--- a/examples/racecar_subscriber.rb
+++ b/examples/racecar_subscriber.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class RacecarSubscriber < ActiveSupport::Subscriber
+  attach_to :racecar
+
+  def process_batch(event)
+    counter_by(:processed_message_total).increment(by: event.payload[:message_count], labels: { topic: event.payload[:topic] })
+  end
+
+  def process_message(event)
+    counter_by(:processed_message_total).increment(by: 1, labels: { topic: event.payload[:topic] })
+  end
+
+  def produce_message(event)
+    counter_by(:produced_message_total).increment(by: 1, labels: { topic: event.payload[:topic] })
+  end
+
+  private
+
+  def counter_by(name)
+    counter = use_metric(name) { registry.counter(name, docstring: '', labels: [:topic]) }
+  end
+
+  def use_metric(name)
+    registry.exist?(name) ? registry.get(name) : yield
+  end
+
+  def prometheus_registry
+    @prometheus_registry ||= Prometheus::Client.registry
+  end
+end

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -50,6 +50,10 @@ module Racecar
         configure_datadog
       end
 
+      if config.prometheus_enabled
+        configure_prometheus
+      end
+
       $stderr.puts "=> Wrooooom!"
 
       if config.daemonize
@@ -150,6 +154,18 @@ module Racecar
         datadog.namespace = config.datadog_namespace unless config.datadog_namespace.nil?
         datadog.tags      = config.datadog_tags unless config.datadog_tags.nil?
       end
+    end
+
+    def configure_prometheus
+      require_relative './prometheus'
+
+      Prometheus.configure do |prometheus|
+        prometheus.endpoint = config.prometheus_endpoint if config.prometheus_endpoint
+        prometheus.registry = config.prometheus_registry if config.prometheus_registry
+        prometheus.port     = config.prometheus_port if config.prometheus_port
+      end
+
+      Prometheus.run
     end
   end
 end

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -150,6 +150,18 @@ module Racecar
     desc "Tags that should always be set on Datadog metrics"
     list :datadog_tags
 
+    desc "Enable Prometheus metrics"
+    boolean :prometheus_enabled, default: false
+
+    desc "The endpoint of the Prometheus client"
+    string :prometheus_endpoint
+
+    desc "The registry instance of the Prometheus client"
+    string :prometheus_registry
+
+    desc "The port of the Prometheus client"
+    integer :prometheus_port
+
     desc "Whether to check the server certificate is valid for the hostname"
     boolean :ssl_verify_hostname, default: true
 

--- a/lib/racecar/prometheus.rb
+++ b/lib/racecar/prometheus.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+begin
+  require 'rack'
+  require 'prometheus/middleware/exporter'
+rescue LoadError
+  $stderr.puts "In order to report Kafka client metrics to Prometheus you need to install the `rack` and `prometheus-client` gems."
+  raise
+end
+
+module Racecar
+  module Prometheus
+    class << self
+      def configure
+        yield self
+      end
+
+      def endpoint
+        @endpoint ||= nil
+      end
+
+      def endpoint=(endpoint)
+        @endpoint = endpoint
+      end
+
+      def port
+        @port ||= 80
+      end
+
+      def port=(port)
+        @port = port
+      end
+
+      def registry
+        @registry ||= nil
+      end
+
+      def registry=(registry)
+        @registry = registry
+      end
+
+      def config
+        config = {}
+        config.merge!(path: endpoint) if endpoint
+        config.merge!(registry: registry) if registry
+        config
+      end
+
+      def app
+        @app ||= begin
+          current_config = config
+
+          Rack::Builder.new do
+            use Rack::Deflater
+            use ::Prometheus::Middleware::Exporter, current_config
+
+            run Proc.new { |env|
+              ['200', {'Content-Type' => 'text/html'}, ['OK']]
+            }
+          end
+        end
+      end
+
+      def run
+        Thread.new do
+          $stderr.puts "=> Exposing Prometheus metrics on #{ endpoint.nil? ? '/metrics' : endpoint} with port #{port}"
+
+          Rack::Handler::WEBrick.run(app, Port: port) do |server|
+            ['QUIT', 'INT', 'TERM'].each do |signal|
+              trap(signal) { server.shutdown }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "dogstatsd-ruby", ">= 4.0.0", "< 5.0.0"
   spec.add_development_dependency "activesupport", ">= 4.0", "< 6.1"
+  spec.add_development_dependency "prometheus-client", ">= 2.1.0"
+  spec.add_development_dependency "rack"
 end

--- a/spec/prometheus_spec.rb
+++ b/spec/prometheus_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "racecar/prometheus"
+
+RSpec.describe Racecar::Prometheus do
+  subject(:prometheus_klass) { described_class }
+
+  describe '.endpoint' do
+    it { expect(prometheus_klass.endpoint).to be_nil }
+
+    context 'when value is updated' do
+      let(:custom_endpoint) { '/custom_endpoint' }
+
+      before { prometheus_klass.endpoint = custom_endpoint }
+
+      it { expect(prometheus_klass.endpoint).to eq(custom_endpoint) }
+    end
+  end
+
+  describe '.port' do
+    it { expect(prometheus_klass.port).to eq(80) }
+
+    context 'when value is updated' do
+      let(:custom_port) { 8080 }
+
+      before { prometheus_klass.port = custom_port }
+
+      it { expect(prometheus_klass.port).to eq(custom_port) }
+    end
+  end
+
+  describe '.registry' do
+    it { expect(prometheus_klass.registry).to be_nil }
+
+    context 'when value is updated' do
+      let(:custom_registry) { 'registry' }
+
+      before { prometheus_klass.registry = custom_registry }
+
+      it { expect(prometheus_klass.registry).to eq(custom_registry) }
+    end
+  end
+
+  describe '.config' do
+    context 'with default values' do
+      before do
+        prometheus_klass.endpoint = nil
+        prometheus_klass.registry = nil
+      end
+
+      it { expect(prometheus_klass.config).to eq({}) }
+    end
+
+    context 'with custom values' do
+      let(:endpoint) { '/endpoint' }
+      let(:registry) { 'MyRegistry' }
+
+      before do
+        prometheus_klass.endpoint = endpoint
+        prometheus_klass.registry = registry
+      end
+
+      it { expect(prometheus_klass.config).to eq({ path: endpoint, registry: registry }) }
+    end
+  end
+end


### PR DESCRIPTION
The main goal is to provide an easy way to allow scraping metrics from consumers using Prometheus.

Currently, we could use https://github.com/prometheus/client_ruby#pushgateway to export metrics to Prometheus, but this adds an extra layer of complexity in which the code that sends metrics blocks the current consumer, so it forces to add non-blocking code. It also implies that you will start to send a lot of POST request per record consumed.

To solve this, this solution creates a rack server with the Prometheus client in a thread, so it can be scraped by a Prometheus instance.

It also provides an example of how to use ActiveSupport::Subscriber to add some basic metrics instrumented by Racecar. 