### PR TITLE
fix docker-compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.1


### PR DESCRIPTION
refs https://github.com/zendesk/racecar/pull/225

Without this version bump docker-compose 1.25.0 (Debian) complains about:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services.broker: 'healthcheck'
Unsupported config option for services.zookeeper: 'healthcheck'
services.wait-for-healthy-services.depends_on contains an invalid type, it should be an array
```