### PR TITLE
Make stats interval directly configurable, disable if no callback is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ All timeouts are defined in number of seconds.
 * `socket_timeout` – How long to wait when trying to communicate with a Kafka broker. Default is 30 seconds.
 * `max_wait_time` – How long to allow the Kafka brokers to wait before returning messages. A higher number means larger batches, at the cost of higher latency. Default is 1 second.
 * `message_timeout` – How long to try to deliver a produced message before finally giving up. Default is 5 minutes. Transient errors are automatically retried. If a message delivery fails, the current read message batch is retried.
+* `statistics_interval` – How frequently librdkafka should publish statistics about its consumers and producers; you must also add a `statistics_callback` method to your processor, otherwise the stats are disabled. The default is 1 second, however this can be quite memory hungry, so you may want to tune this and monitor.
 
 #### Memory & network usage
 

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -224,7 +224,7 @@ module Racecar
         "queued.min.messages"     => @config.min_message_queue_size,
         "session.timeout.ms"      => @config.session_timeout * 1000,
         "socket.timeout.ms"       => @config.socket_timeout * 1000,
-        "statistics.interval.ms"  => 1000, # 1s is the highest granularity offered
+        "statistics.interval.ms"  => @config.statistics_interval_ms
       }
       config.merge! @config.rdkafka_consumer
       config.merge! subscription.additional_config

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -133,7 +133,7 @@ module Racecar
       producer_config = {
         "bootstrap.servers"      => config.brokers.join(","),
         "client.id"              => config.client_id,
-        "statistics.interval.ms" => 1000,
+        "statistics.interval.ms" => config.statistics_interval_ms,
         "message.timeout.ms"     => config.message_timeout * 1000,
       }
       producer_config["compression.codec"] = config.producer_compression_codec.to_s unless config.producer_compression_codec.nil?

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -175,4 +175,50 @@ RSpec.describe Racecar::Config do
       expect(config.inspect.split("\n")).to include %(client_id = "elvis")
     end
   end
+
+  describe "#statistics_interval_ms" do
+    before do
+      # If we set this for real, it can't then be unset (at least not without delving into
+      # the guts of Rdkafka)
+      allow(Rdkafka::Config).to receive(:statistics_callback).and_return(stats_callback)
+    end
+
+    context "when there is no statistics_callback defined in the rdkafka config" do
+      let(:stats_callback) { nil }
+
+      context "when statistics_interval is not set" do
+        it "returns 0" do
+          expect(config.statistics_interval_ms).to eq(0)
+        end
+      end
+
+      context "when statistics_interval is set" do
+        before { config.statistics_interval = 5 }
+
+        it "returns 0" do
+          expect(config.statistics_interval_ms).to eq(0)
+        end
+      end
+    end
+
+    context "when there is a statistics_callback defined in the rdkafka config" do
+      let(:stats_callback) do
+        ->(stats) { puts "Nice, a stats callback" }
+      end
+
+      context "when statistics_interval is not set" do
+        it "returns 1000 by default" do
+          expect(config.statistics_interval_ms).to eq(1000)
+        end
+      end
+
+      context "when statistics_interval is set" do
+        before { config.statistics_interval = 5 }
+
+        it "returns the interval in ms" do
+          expect(config.statistics_interval_ms).to eq(5000)
+        end
+      end
+    end
+  end
 end

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -52,9 +52,9 @@ module IntegrationHelper
     puts "Creating topic #{topic}"
     msg, process = run_kafka_command("kafka-topics --bootstrap-server #{kafka_brokers} --create "\
                                      "--topic #{topic} --partitions #{partitions} --replication-factor 1")
-    return if process.exitstatus.zero?
-
-    puts "Kafka topic creation exited with status #{process.exitstatus}, message: #{msg}"
+    unless process.exitstatus.zero?
+      raise "Kafka topic creation exited with status #{process.exitstatus}, message: #{msg}"
+    end
   end
 
   def wait_for_assignments(group_id:, topic:, expected_members_count:)


### PR DESCRIPTION
The statistics provided by librdkafka can be quite memory intensive, especially where an application is not doing anything with them. This PR makes the following changes:
- Allows the `statistics_interval` to be configured directly in the config
- Disables the statistics if no callback has been configured in `Rdkafka` - if nobody is listening, we don't need em