### PR TITLE
Bump king_konf to v1.0 in the v1-stable branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Require king_konf v1.0 or higher.
+
 ## racecar v1.2.0
 
 * Support for `ssl_client_cert_key_password` (#173).

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "king_konf", "~> 0.3.7"
+  spec.add_runtime_dependency "king_konf", "~> 1.0"
   spec.add_runtime_dependency "ruby-kafka", "~> 1.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]


### PR DESCRIPTION
This change is already in master and it has no breaking changes, I would like to get it into `v1-stable` to keep using with the latest https://github.com/zendesk/delivery_boy which already depends on `"king_konf", "~> 1.0"` (due to the latest `racecar`, so kinda circular dependency).

Thanks in advance.