### PR TITLE
Native Heroku Kafka support

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,17 +439,16 @@ The important part is the `strategy.type` value, which tells Kubernetes how to u
 
 Instead, the `Recreate` update strategy should be used. It completely tears down the existing containers before starting all of the new containers simultaneously, allowing for a single synchronization stage and a much faster, more stable deployment update.
 
-#### Deploying to Heroku (Making use of Heroku Kafka ENVs)
+#### Deploying to Heroku (Making use of Heroku Kafka add-on ENVs)
 
-If you run your applications in Heroku and/or use Heroku Kafka as the broker, you will be provided with 4 ENVs to connect to the broker: `KAFKA_URL`, `KAFKA_TRUSTED_CERT`, `KAFKA_CLIENT_CERT`, `KAFKA_CLIENT_CERT_KEY`. Find [relavent Heroku Documentation here](https://devcenter.heroku.com/articles/kafka-on-heroku#connecting-to-a-kafka-cluster).
+If you run your applications in Heroku and/or use Heroku Kafka as the broker, you are be provided with 4 ENVs by the add-on to connect to the broker: `KAFKA_URL`, `KAFKA_TRUSTED_CERT`, `KAFKA_CLIENT_CERT`, `KAFKA_CLIENT_CERT_KEY`.
 
-Racecar provides an easy and flexible way to configure your consumer to work with these ENVs. Just requiring `racecar/heroku` in your consumer file or in one of your rails initializer files will set the Racecar configuration variables to the parsed ENV values.
+Racecar provides an easy way to configure consumers to work with these ENVs. Just requiring `racecar/heroku` in the consumer file or in one of the rails initializer files will set the Racecar configuration variables to the parsed ENV values.
 
-If your Kafka broker is named differently from `KAFKA`, you can tell Racecar to use that name by setting `Racecar::Heroku.kafka_name = NEW_KAFKA`. This will make Racecar to read values from ENVs `NEW_KAFKA_URL`, `NEW_KAFKA_TRUSTED_CERT` ... etc.
+Please note that this will work only if the Heroku Kafka add-on is aliased to the default name `KAFKA`
 
 ```ruby
-require "racecar/heroku.rb"
-Racecar::Heroku.kafka_name = "NEW_KAFKA"
+require "racecar/heroku"
 
 class OrderUpdatesConsumer < Racecar::Consumer
   subscribes_to "order_updates"

--- a/lib/racecar/heroku.rb
+++ b/lib/racecar/heroku.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'tempfile'
+
+# Heroku Kafka addon provides 4 ENVs to connect to their Kafka Broker
+# KAFKA_TRUSTED_CERT, KAFKA_CLIENT_CERT, KAFKA_CLIENT_CERT_KEY, KAFKA_URL
+# "KAFKA" is the default name of the addon, which is configurable
+
+$stderr.puts "=> Loading configuration from Heroku Kafka ENVs"
+
+module Racecar
+  module Heroku
+    def self.kafka_name=(kafka_name, log_and_exit_if_invalid_env = true)
+      [
+        "#{kafka_name}_URL",
+        "#{kafka_name}_TRUSTED_CERT",
+        "#{kafka_name}_CLIENT_CERT",
+        "#{kafka_name}_CLIENT_CERT_KEY"
+      ]. each do |env_name|
+        if ENV[env_name].nil? && log_and_exit_if_invalid_env
+          $stderr.puts "Error: ENV #{env_name} is not set"
+          exit 1
+        end
+      end
+      Racecar.configure do |config|
+        ca_cert = ENV["#{kafka_name}_TRUSTED_CERT"]
+        client_cert = ENV["#{kafka_name}_CLIENT_CERT"]
+        client_cert_key = ENV["#{kafka_name}_CLIENT_CERT_KEY"]
+
+        tmp_file_path = lambda do |data|
+          tempfile = Tempfile.new(['', '.pem'])
+          tempfile << data
+          tempfile.close
+          tempfile.path
+        end
+
+        config.security_protocol = :ssl
+        config.ssl_ca_location = tmp_file_path.call(ca_cert)
+        config.ssl_certificate_location = tmp_file_path.call(client_cert)
+        config.ssl_key_location = tmp_file_path.call(client_cert_key)
+
+        config.brokers = ENV["#{kafka_name}_URL"].to_s.gsub('kafka+ssl://', '').split(',')
+      end
+    end
+  end
+end
+
+Racecar::Heroku.send(:kafka_name=, 'KAFKA', false)

--- a/spec/heroku_spec.rb
+++ b/spec/heroku_spec.rb
@@ -7,38 +7,17 @@ RSpec.describe "Racecar::Heroku" do
 
   context 'when "racecar/heroku" is required' do
     context 'when one or more of Heroku Kafka ENVs are not set' do
-      context 'when Racecar::Heroku.kafka_name= is not called (default behavior)' do
-        it 'doesn\'t do anything' do
-          expect($stderr).not_to receive(:puts).with("Error: ENV KAFKA_CLIENT_CERT_KEY is not set")
+      it 'logs error about the missing ENV and exits with code 1' do
+        expect($stderr).to receive(:puts).with("=> Loading configuration from Heroku Kafka ENVs")
+        expect($stderr).to receive(:puts).with("Error: ENV KAFKA_CLIENT_CERT_KEY is not set")
 
-          with_env('KAFKA_URL', 'valid-url') do
-            with_env('KAFKA_TRUSTED_CERT', 'valid trusted cert') do
-              with_env('KAFKA_CLIENT_CERT', 'valid client cert') do
-                # ENV KAFKA_CLIENT_CERT_KEY is not set
-                expect do
-                  load "racecar/heroku.rb"
-                end.not_to raise_exception
-              end
-            end
-          end
-        end
-      end
-
-      context 'when Racecar::Heroku.kafka_name= is called (overriding behavior)' do
-        it 'logs the error and exits with status 1' do
-
-          expect($stderr).to receive(:puts).with("=> Loading configuration from Heroku Kafka ENVs")
-          expect($stderr).to receive(:puts).with("Error: ENV KAFKA2_CLIENT_CERT_KEY is not set")
-
-          with_env('KAFKA2_URL', 'valid-url') do
-            with_env('KAFKA2_TRUSTED_CERT', 'valid trusted cert') do
-              with_env('KAFKA2_CLIENT_CERT', 'valid client cert') do
-                # ENV KAFKA2_CLIENT_CERT_KEY is not set
-                expect do
-                  load "racecar/heroku.rb"
-                  Racecar::Heroku.kafka_name = 'KAFKA2'
-                end.to raise_exception(SystemExit)
-              end
+        with_env('KAFKA_URL', 'valid-url') do
+          with_env('KAFKA_TRUSTED_CERT', 'valid trusted cert') do
+            with_env('KAFKA_CLIENT_CERT', 'valid client cert') do
+              # ENV KAFKA_CLIENT_CERT_KEY is not set
+              expect do
+                load "racecar/heroku.rb"
+              end.to raise_exception(SystemExit)
             end
           end
         end
@@ -46,99 +25,49 @@ RSpec.describe "Racecar::Heroku" do
     end
 
     context 'when all of the Heroku Kafka ENVs are set' do
-      context 'when Racecar::Heroku.kafka_name= is not called (default behavior)' do
-        before do
-          with_env('KAFKA_URL', 'kafka+ssl://url1,kafka+ssl://url2') do
-            with_env('KAFKA_TRUSTED_CERT', 'valid trusted cert') do
-              with_env('KAFKA_CLIENT_CERT', 'valid client cert') do
-                with_env('KAFKA_CLIENT_CERT_KEY', 'valid client cert key') do
-                  Racecar.config = config
-                  load "racecar/heroku.rb"
-                end
+      before do
+        with_env('KAFKA_URL', 'kafka+ssl://url1,kafka+ssl://url2') do
+          with_env('KAFKA_TRUSTED_CERT', 'valid trusted cert') do
+            with_env('KAFKA_CLIENT_CERT', 'valid client cert') do
+              with_env('KAFKA_CLIENT_CERT_KEY', 'valid client cert key') do
+                Racecar.config = config
+                load "racecar/heroku.rb"
               end
             end
           end
-        end
-
-        it 'sets the config.security_protocol to :ssl' do
-          expect(Racecar.config.security_protocol).to eq :ssl
-        end
-
-        it 'sets the config.brokers to KAFKA_URL' do
-          expect(Racecar.config.brokers).to eq ['url1', 'url2']
-        end
-
-        it 'sets the config.ssl_ca_location to a temporary file with contents of KAFKA_TRUSTED_CERT' do
-          file_extention = Racecar.config.ssl_ca_location.split('.').last
-          file_contents = File.read(Racecar.config.ssl_ca_location)
-
-          expect(file_extention).to eq 'pem'
-          expect(file_contents).to eq 'valid trusted cert'
-        end
-
-        it 'sets the config.ssl_certificate_location to a temporary file with contents of KAFKA_CLIENT_CERT' do
-          file_extention = Racecar.config.ssl_certificate_location.split('.').last
-          file_contents = File.read(Racecar.config.ssl_certificate_location)
-
-          expect(file_extention).to eq 'pem'
-          expect(file_contents).to eq 'valid client cert'
-        end
-
-        it 'sets the config.ssl_key_location to a temporary file with contents of KAFKA_CLIENT_CERT_KEY' do
-          file_extention = Racecar.config.ssl_key_location.split('.').last
-          file_contents = File.read(Racecar.config.ssl_key_location)
-
-          expect(file_extention).to eq 'pem'
-          expect(file_contents).to eq 'valid client cert key'
         end
       end
 
-      context 'when Racecar::Heroku.kafka_name= is called with \'PURPLE_KAFKA\'' do
-        before do
-          with_env('PURPLE_KAFKA_URL', 'kafka+ssl://purple-url1,kafka+ssl://purple-url2') do
-            with_env('PURPLE_KAFKA_TRUSTED_CERT', 'valid purple trusted cert') do
-              with_env('PURPLE_KAFKA_CLIENT_CERT', 'valid purple client cert') do
-                with_env('PURPLE_KAFKA_CLIENT_CERT_KEY', 'valid purple client cert key') do
-                  Racecar.config = config
-                  load "racecar/heroku.rb"
-                  Racecar::Heroku.kafka_name = 'PURPLE_KAFKA'
-                end
-              end
-            end
-          end
-        end
+      it 'sets the config.security_protocol to :ssl' do
+        expect(Racecar.config.security_protocol).to eq :ssl
+      end
 
-        it 'sets the config.security_protocol to :ssl' do
-          expect(Racecar.config.security_protocol).to eq :ssl
-        end
+      it 'sets the config.brokers to KAFKA_URL' do
+        expect(Racecar.config.brokers).to eq ['url1', 'url2']
+      end
 
-        it 'sets the config.brokers to PURPLE_KAFKA_URL' do
-          expect(Racecar.config.brokers).to eq ['purple-url1', 'purple-url2']
-        end
+      it 'sets the config.ssl_ca_location to a temporary file with contents of KAFKA_TRUSTED_CERT' do
+        file_extention = Racecar.config.ssl_ca_location.split('.').last
+        file_contents = File.read(Racecar.config.ssl_ca_location)
 
-        it 'sets the config.ssl_ca_location to a temporary file with contents of PURPLE_KAFKA_TRUSTED_CERT' do
-          file_extention = Racecar.config.ssl_ca_location.split('.').last
-          file_contents = File.read(Racecar.config.ssl_ca_location)
+        expect(file_extention).to eq 'pem'
+        expect(file_contents).to eq 'valid trusted cert'
+      end
 
-          expect(file_extention).to eq 'pem'
-          expect(file_contents).to eq 'valid purple trusted cert'
-        end
+      it 'sets the config.ssl_certificate_location to a temporary file with contents of KAFKA_CLIENT_CERT' do
+        file_extention = Racecar.config.ssl_certificate_location.split('.').last
+        file_contents = File.read(Racecar.config.ssl_certificate_location)
 
-        it 'sets the config.ssl_certificate_location to a temporary file with contents of PURPLE_KAFKA_CLIENT_CERT' do
-          file_extention = Racecar.config.ssl_certificate_location.split('.').last
-          file_contents = File.read(Racecar.config.ssl_certificate_location)
+        expect(file_extention).to eq 'pem'
+        expect(file_contents).to eq 'valid client cert'
+      end
 
-          expect(file_extention).to eq 'pem'
-          expect(file_contents).to eq 'valid purple client cert'
-        end
+      it 'sets the config.ssl_key_location to a temporary file with contents of KAFKA_CLIENT_CERT_KEY' do
+        file_extention = Racecar.config.ssl_key_location.split('.').last
+        file_contents = File.read(Racecar.config.ssl_key_location)
 
-        it 'sets the config.ssl_key_location to a temporary file with contents of PURPLE_KAFKA_CLIENT_CERT_KEY' do
-          file_extention = Racecar.config.ssl_key_location.split('.').last
-          file_contents = File.read(Racecar.config.ssl_key_location)
-
-          expect(file_extention).to eq 'pem'
-          expect(file_contents).to eq 'valid purple client cert key'
-        end
+        expect(file_extention).to eq 'pem'
+        expect(file_contents).to eq 'valid client cert key'
       end
     end
   end

--- a/spec/heroku_spec.rb
+++ b/spec/heroku_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+# require "racecar/heroku"
+require "racecar/config"
+
+RSpec.describe "Racecar::Heroku" do
+  let(:config) { Racecar::Config.new }
+
+  context 'when "racecar/heroku" is required' do
+    context 'when one or more of Heroku Kafka ENVs are not set' do
+      context 'when Racecar::Heroku.kafka_name= is not called (default behavior)' do
+        it 'doesn\'t do anything' do
+          expect($stderr).not_to receive(:puts).with("Error: ENV KAFKA_CLIENT_CERT_KEY is not set")
+          
+          with_env('KAFKA_URL', 'valid-url') do
+            with_env('KAFKA_TRUSTED_CERT', 'valid trusted cert') do
+              with_env('KAFKA_CLIENT_CERT', 'valid client cert') do
+                # ENV KAFKA_CLIENT_CERT_KEY is not set
+                expect do
+                  load "racecar/heroku.rb"
+                end.not_to raise_exception
+              end
+            end
+          end
+        end
+      end
+
+      context 'when Racecar::Heroku.kafka_name= is called (overriding behavior)' do
+        it 'logs the error and exits with status 1' do
+        
+          expect($stderr).to receive(:puts).with("=> Loading configuration from Heroku Kafka ENVs")
+          expect($stderr).to receive(:puts).with("Error: ENV KAFKA2_CLIENT_CERT_KEY is not set")
+  
+          with_env('KAFKA2_URL', 'valid-url') do
+            with_env('KAFKA2_TRUSTED_CERT', 'valid trusted cert') do
+              with_env('KAFKA2_CLIENT_CERT', 'valid client cert') do
+                # ENV KAFKA2_CLIENT_CERT_KEY is not set
+                expect do
+                  load "racecar/heroku.rb"
+                  Racecar::Heroku.kafka_name = 'KAFKA2'
+                end.to raise_exception(SystemExit)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when all of the Heroku Kafka ENVs are set' do
+      context 'when Racecar::Heroku.kafka_name= is not called (default behavior)' do
+        before do
+          with_env('KAFKA_URL', 'kafka+ssl://url1,kafka+ssl://url2') do
+            with_env('KAFKA_TRUSTED_CERT', 'valid trusted cert') do
+              with_env('KAFKA_CLIENT_CERT', 'valid client cert') do
+                with_env('KAFKA_CLIENT_CERT_KEY', 'valid client cert key') do
+                  Racecar.config = config
+                  load "racecar/heroku.rb"
+                end
+              end
+            end
+          end
+        end
+  
+        it 'sets the config.security_protocol to :ssl' do
+          expect(Racecar.config.security_protocol).to eq :ssl
+        end
+  
+        it 'sets the config.brokers to KAFKA_URL' do
+          expect(Racecar.config.brokers).to eq ['url1', 'url2']
+        end
+  
+        it 'sets the config.ssl_ca_location to a temporary file with contents of KAFKA_TRUSTED_CERT' do
+          file_extention = Racecar.config.ssl_ca_location.split('.').last
+          file_contents = File.read(Racecar.config.ssl_ca_location)
+  
+          expect(file_extention).to eq 'pem'
+          expect(file_contents).to eq 'valid trusted cert'
+        end
+  
+        it 'sets the config.ssl_certificate_location to a temporary file with contents of KAFKA_CLIENT_CERT' do
+          file_extention = Racecar.config.ssl_certificate_location.split('.').last
+          file_contents = File.read(Racecar.config.ssl_certificate_location)
+  
+          expect(file_extention).to eq 'pem'
+          expect(file_contents).to eq 'valid client cert'
+        end
+        
+        it 'sets the config.ssl_key_location to a temporary file with contents of KAFKA_CLIENT_CERT_KEY' do
+          file_extention = Racecar.config.ssl_key_location.split('.').last
+          file_contents = File.read(Racecar.config.ssl_key_location)
+  
+          expect(file_extention).to eq 'pem'
+          expect(file_contents).to eq 'valid client cert key'
+        end
+      end
+
+      context 'when Racecar::Heroku.kafka_name= is called with \'PURPLE_KAFKA\'' do
+        before do
+          with_env('PURPLE_KAFKA_URL', 'kafka+ssl://purple-url1,kafka+ssl://purple-url2') do
+            with_env('PURPLE_KAFKA_TRUSTED_CERT', 'valid purple trusted cert') do
+              with_env('PURPLE_KAFKA_CLIENT_CERT', 'valid purple client cert') do
+                with_env('PURPLE_KAFKA_CLIENT_CERT_KEY', 'valid purple client cert key') do
+                  Racecar.config = config
+                  load "racecar/heroku.rb"
+                  Racecar::Heroku.kafka_name = 'PURPLE_KAFKA'
+                end
+              end
+            end
+          end
+        end
+  
+        it 'sets the config.security_protocol to :ssl' do
+          expect(Racecar.config.security_protocol).to eq :ssl
+        end
+  
+        it 'sets the config.brokers to PURPLE_KAFKA_URL' do
+          expect(Racecar.config.brokers).to eq ['purple-url1', 'purple-url2']
+        end
+  
+        it 'sets the config.ssl_ca_location to a temporary file with contents of PURPLE_KAFKA_TRUSTED_CERT' do
+          file_extention = Racecar.config.ssl_ca_location.split('.').last
+          file_contents = File.read(Racecar.config.ssl_ca_location)
+  
+          expect(file_extention).to eq 'pem'
+          expect(file_contents).to eq 'valid purple trusted cert'
+        end
+  
+        it 'sets the config.ssl_certificate_location to a temporary file with contents of PURPLE_KAFKA_CLIENT_CERT' do
+          file_extention = Racecar.config.ssl_certificate_location.split('.').last
+          file_contents = File.read(Racecar.config.ssl_certificate_location)
+  
+          expect(file_extention).to eq 'pem'
+          expect(file_contents).to eq 'valid purple client cert'
+        end
+        
+        it 'sets the config.ssl_key_location to a temporary file with contents of PURPLE_KAFKA_CLIENT_CERT_KEY' do
+          file_extention = Racecar.config.ssl_key_location.split('.').last
+          file_contents = File.read(Racecar.config.ssl_key_location)
+  
+          expect(file_extention).to eq 'pem'
+          expect(file_contents).to eq 'valid purple client cert key'
+        end
+      end
+    end
+  end
+end

--- a/spec/heroku_spec.rb
+++ b/spec/heroku_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# require "racecar/heroku"
 require "racecar/config"
 
 RSpec.describe "Racecar::Heroku" do
@@ -11,7 +10,7 @@ RSpec.describe "Racecar::Heroku" do
       context 'when Racecar::Heroku.kafka_name= is not called (default behavior)' do
         it 'doesn\'t do anything' do
           expect($stderr).not_to receive(:puts).with("Error: ENV KAFKA_CLIENT_CERT_KEY is not set")
-          
+
           with_env('KAFKA_URL', 'valid-url') do
             with_env('KAFKA_TRUSTED_CERT', 'valid trusted cert') do
               with_env('KAFKA_CLIENT_CERT', 'valid client cert') do
@@ -27,10 +26,10 @@ RSpec.describe "Racecar::Heroku" do
 
       context 'when Racecar::Heroku.kafka_name= is called (overriding behavior)' do
         it 'logs the error and exits with status 1' do
-        
+
           expect($stderr).to receive(:puts).with("=> Loading configuration from Heroku Kafka ENVs")
           expect($stderr).to receive(:puts).with("Error: ENV KAFKA2_CLIENT_CERT_KEY is not set")
-  
+
           with_env('KAFKA2_URL', 'valid-url') do
             with_env('KAFKA2_TRUSTED_CERT', 'valid trusted cert') do
               with_env('KAFKA2_CLIENT_CERT', 'valid client cert') do
@@ -60,35 +59,35 @@ RSpec.describe "Racecar::Heroku" do
             end
           end
         end
-  
+
         it 'sets the config.security_protocol to :ssl' do
           expect(Racecar.config.security_protocol).to eq :ssl
         end
-  
+
         it 'sets the config.brokers to KAFKA_URL' do
           expect(Racecar.config.brokers).to eq ['url1', 'url2']
         end
-  
+
         it 'sets the config.ssl_ca_location to a temporary file with contents of KAFKA_TRUSTED_CERT' do
           file_extention = Racecar.config.ssl_ca_location.split('.').last
           file_contents = File.read(Racecar.config.ssl_ca_location)
-  
+
           expect(file_extention).to eq 'pem'
           expect(file_contents).to eq 'valid trusted cert'
         end
-  
+
         it 'sets the config.ssl_certificate_location to a temporary file with contents of KAFKA_CLIENT_CERT' do
           file_extention = Racecar.config.ssl_certificate_location.split('.').last
           file_contents = File.read(Racecar.config.ssl_certificate_location)
-  
+
           expect(file_extention).to eq 'pem'
           expect(file_contents).to eq 'valid client cert'
         end
-        
+
         it 'sets the config.ssl_key_location to a temporary file with contents of KAFKA_CLIENT_CERT_KEY' do
           file_extention = Racecar.config.ssl_key_location.split('.').last
           file_contents = File.read(Racecar.config.ssl_key_location)
-  
+
           expect(file_extention).to eq 'pem'
           expect(file_contents).to eq 'valid client cert key'
         end
@@ -108,35 +107,35 @@ RSpec.describe "Racecar::Heroku" do
             end
           end
         end
-  
+
         it 'sets the config.security_protocol to :ssl' do
           expect(Racecar.config.security_protocol).to eq :ssl
         end
-  
+
         it 'sets the config.brokers to PURPLE_KAFKA_URL' do
           expect(Racecar.config.brokers).to eq ['purple-url1', 'purple-url2']
         end
-  
+
         it 'sets the config.ssl_ca_location to a temporary file with contents of PURPLE_KAFKA_TRUSTED_CERT' do
           file_extention = Racecar.config.ssl_ca_location.split('.').last
           file_contents = File.read(Racecar.config.ssl_ca_location)
-  
+
           expect(file_extention).to eq 'pem'
           expect(file_contents).to eq 'valid purple trusted cert'
         end
-  
+
         it 'sets the config.ssl_certificate_location to a temporary file with contents of PURPLE_KAFKA_CLIENT_CERT' do
           file_extention = Racecar.config.ssl_certificate_location.split('.').last
           file_contents = File.read(Racecar.config.ssl_certificate_location)
-  
+
           expect(file_extention).to eq 'pem'
           expect(file_contents).to eq 'valid purple client cert'
         end
-        
+
         it 'sets the config.ssl_key_location to a temporary file with contents of PURPLE_KAFKA_CLIENT_CERT_KEY' do
           file_extention = Racecar.config.ssl_key_location.split('.').last
           file_contents = File.read(Racecar.config.ssl_key_location)
-  
+
           expect(file_extention).to eq 'pem'
           expect(file_contents).to eq 'valid purple client cert key'
         end


### PR DESCRIPTION
Goal is to provide an easy mechanism to connect to Heroku Kafka using the ENVs provided by the broker.

Currently users have to create an initizlizer to read these ENVs and set `Racecar::Config` appropriately. Heroku Kafka provides the certificates as strings, but Racecar (RDKafka) needs them as a files.

To solve this, this solution creates the file `lib/heroku.rb`, which does all the work of parsing the ENVs and setting them to the Config appropriately. Users can just `require 'racecar/heroku'` on top of the Consumer class or in an initializer to make Racecar work with the ENVs provided by Heroku Kafka.