### PR TITLE
Require Ruby 2.5 when using gem + bump version to v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## racecar v2.3.1
+
+* Require Ruby 2.5 when using gem (#256)
+
 ## racecar v2.3.0
 
 * Add native support for Heroku (#248)

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Racecar
-  VERSION = "2.3.0"
+  VERSION = "2.3.1"
 end

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.5'
+
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
   spec.add_runtime_dependency "rdkafka",   "~> 0.8.0"
 


### PR DESCRIPTION
The gem is now using syntax no longer works on older Rubies.

Fixes #252 

P.s: I've included the version bump, let me know if you'd prefer that I remove it.
P.s.2.: Would be great if version 2.3.0 was yanked from Rubygems.org, so that older Rubies would once again pick 2.2.0 :)