### PR TITLE
Restore support for Ruby 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ["2.4", 2.5", "2.6", "3.0"]
+        ruby-version: ["2.4", "2.5", "2.6", "3.0"]
 
     steps:
     - uses: zendesk/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ["2.5", "2.6", "3.0"]
+        ruby-version: ["2.4", 2.5", "2.6", "3.0"]
 
     steps:
     - uses: zendesk/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in racecar.gemspec
 gemspec
+
+# We actually support version 6.0 (see gemspec); this extra restriction is added just for running the test suite also
+# on Ruby 2.4, which activesupport 6.0 no longer supports
+gem 'activesupport', '< 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,23 +8,22 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.4)
+    activesupport (5.2.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.4.4)
     dogstatsd-ruby (4.8.2)
     ffi (1.15.4)
-    i18n (1.8.5)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     king_konf (1.0.0)
     method_source (1.0.0)
     mini_portile2 (2.7.0)
-    minitest (5.14.2)
+    minitest (5.14.4)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -48,15 +47,14 @@ GEM
     rspec-support (3.10.2)
     thread_safe (0.3.6)
     timecop (0.9.2)
-    tzinfo (1.2.8)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 4.0, < 6.1)
+  activesupport (< 6.0)
   bundler (>= 1.13, < 3)
   dogstatsd-ruby (>= 4.0.0, < 5.0.0)
   pry

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.4'
+
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
   spec.add_runtime_dependency "rdkafka",   "~> 0.10.0"
 


### PR DESCRIPTION
The "ensure inside a block without an explicit begin/end" feature is a Ruby 2.5 feature (see <https://bugs.ruby-lang.org/issues/12906>) and its usage broke racecar usage on Ruby 2.4 (#252).

By re-adding the begin/end, it all works again. To make sure it keeps working, I've also added Ruby 2.4 to the test matrix on
GitHub.

I also added a `spec.required_ruby_version` to the gemspec, to make it clear which versions are tested. I tried checking if Ruby 2.3 or older could be trivially supported, but in fact the `rdkafka` dependency also requires 2.4+ and thus it implicitly sets the minimum bound for racecar.

This is an alternative to #256.

Fixes #252

P.s: I've included the version bump, let me know if you'd prefer that I remove it.