### PR TITLE
support sasl_mechanisms config

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -80,6 +80,9 @@ module Racecar
     desc "Protocol used to communicate with brokers"
     symbol :security_protocol, allowed_values: %i{plaintext ssl sasl_plaintext sasl_ssl}
 
+    desc "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER."
+    symbol :security_mechanisms
+
     desc "File or directory path to CA certificate(s) for verifying the broker's key"
     string :ssl_ca_location
 
@@ -251,6 +254,7 @@ module Racecar
     def rdkafka_security_config
       {
         "security.protocol" => security_protocol,
+        "sasl.mechanisms" => security_mechanisms,
         "enable.ssl.certificate.verification" => ssl_verify_hostname,
         "ssl.ca.location" => ssl_ca_location,
         "ssl.crl.location" => ssl_crl_location,


### PR DESCRIPTION
## What does this parameter used for?

Configuration property: "sasl.mechanisms"

Usage: SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER. NOTE: Despite the name only one mechanism must be configured.

## Why add it?

when connecting to the Kafka in confluent.cloud, this parameter is a mandatory property.

Here is an example to connect confluent kafka.

```ruby
# ruby code

config = {
  :"bootstrap.servers" => "pkc-pgq85.us-west-2.aws.confluent.cloud:9092",
  :"group.id" => "ruby-test",
  :"security.protocol" => "SASL_SSL",
  :"sasl.mechanisms" => "PLAIN",
  :"sasl.username" => 'your username',
  :"sasl.password" => 'your password'
}
consumer = Rdkafka::Config.new(config).consumer
consumer.subscribe("core.onboarding.employees")

consumer.each do |message|
  puts "Message received: #{message}"
end

```
## Reference:

https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html


## Related Issue

https://github.com/zendesk/racecar/issues/254