### PR TITLE
Upgrade to rdkafka 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Update librdkafka version from 1.4.0 to 1.5.0 by upgrading from rdkafka 0.9.0 to 0.10.0. ([#263](https://github.com/zendesk/racecar/pull/263))
+
 ## racecar v2.3.1
 
 * Handle `ERR_NOT_COORDINATOR` (#209)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Update librdkafka version from 1.4.0 to 1.5.0 by upgrading from rdkafka 0.9.0 to 0.10.0. ([#263](https://github.com/zendesk/racecar/pull/263))
+* Update librdkafka version from 1.4.0 to 1.5.0 by upgrading from rdkafka 0.8.0 to 0.10.0. ([#263](https://github.com/zendesk/racecar/pull/263))
 
 ## racecar v2.3.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    racecar (2.3.0)
+    racecar (2.3.1)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.8.0)
+      rdkafka (~> 0.10.0)
 
 GEM
   remote: https://rubygems.org/
@@ -18,18 +18,18 @@ GEM
     concurrent-ruby (1.1.7)
     diff-lcs (1.4.4)
     dogstatsd-ruby (4.8.2)
-    ffi (1.15.3)
+    ffi (1.15.4)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     king_konf (1.0.0)
     method_source (1.0.0)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.7.0)
     minitest (5.14.2)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.1)
-    rdkafka (0.8.1)
+    rdkafka (0.10.0)
       ffi (~> 1.9)
       mini_portile2 (~> 2.1)
       rake (>= 12.3)
@@ -66,4 +66,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.1.4
+   2.2.15

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.8.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.10.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry"

--- a/spec/integration/consumer_spec.rb
+++ b/spec/integration/consumer_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe "running a Racecar consumer", type: :integration do
 
     before do
       create_topic(topic: input_topic, partitions: topic_partitions)
+      create_topic(topic: output_topic, partitions: topic_partitions)
 
       consumer_class.subscribes_to(input_topic)
       consumer_class.output_topic = output_topic


### PR DESCRIPTION
## Why?

My team maintains a stream processing application that uses Racecar. Recently we learned that a known issue with librdkafka 1.4.0 (https://github.com/edenhill/librdkafka/issues/2830) negatively impacts the performance of our application. The latest version of rdkafka, 0.10.0, upgrades the gem to use librdkafka 1.5.0. This PR proposes updating Racecar to use rdkafka 0.10.0.

References:

- Librdkafka 1.5.0 release notes: https://github.com/edenhill/librdkafka/releases?after=v1.6.0-PRE4
- rdkafka-ruby PR upgrading to librdkafka 1.5.0: https://github.com/appsignal/rdkafka-ruby/pull/165

## How?

I made the following changes:

- Updated `racecar.gemspec` to require rdkafka 0.10.0
- Updated test setup in spec/integration/consumer_spec.rb to explicitly create topics instead of relying on Kafka to automatically create the topics. librdkafka 1.5.0+ does not support topic auto-creation.
- Committed the changes to `Gemfile.lock` that were generated by running `bin/setup`

### Testing

I followed the instructions for setting up the Racecar development environment in the README and confirmed (non-dockerized) tests pass locally by running `bundle exec rspec`.

### Considerations

- I noticed that `spec/integration/consumer_spec.rb` tests sometimes fail when I run `bundle exec rspec` but they always pass when I run `bundle exec rspec spec/integration/consumer_spec.rb`. I observed this on both `master` and my branch. I took care to stop and restart the Docker services after each test run.
- As a stopgap, my team is currently using gems built from our own forks of the racecar and rdkafka-ruby repos in production. Merging and releasing the changes in this PR will allow us to avoid using our forks. 

Thanks in advance for your time! 🙇‍♀️ 