### PR TITLE
Add support for dogstatsd-ruby v5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    racecar (2.3.1)
+    racecar (2.4.0)
       king_konf (~> 1.0.0)
       rdkafka (~> 0.10.0)
 
@@ -16,7 +16,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     diff-lcs (1.4.4)
-    dogstatsd-ruby (4.8.2)
+    dogstatsd-ruby (5.2.0)
     ffi (1.15.4)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -56,7 +56,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (< 6.0)
   bundler (>= 1.13, < 3)
-  dogstatsd-ruby (>= 4.0.0, < 5.0.0)
+  dogstatsd-ruby (>= 4.0.0, < 6.0.0)
   pry
   racecar!
   rake (> 10.0)
@@ -64,4 +64,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.2.15
+   2.2.26

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -63,10 +63,14 @@ module Racecar
         clear
       end
 
+      def close
+        @statsd&.close
+      end
+
       private
 
       def clear
-        @statsd && @statsd.close
+        close
         @statsd = nil
       end
     end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -92,6 +92,7 @@ module Racecar
       end
     ensure
       producer.close
+      Racecar::Datadog.close if Object.const_defined?("Racecar::Datadog")
     end
 
     def stop

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "timecop"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 4.0.0", "< 5.0.0"
+  spec.add_development_dependency "dogstatsd-ruby", ">= 4.0.0", "< 6.0.0"
   spec.add_development_dependency "activesupport", ">= 4.0", "< 6.1"
 end


### PR DESCRIPTION
- dogstatsd-ruby v5 buffers metrics before sending them which means they need to be flushed on process shutdown or metrics data may be lost
- The existing `close` method now calls `flush` synchronously https://github.com/DataDog/dogstatsd-ruby/blob/master/lib/datadog/statsd.rb#L331-L334
- This update adds support for dogstatsd-ruby v5 by calling `close` when the process is stopped