### PR TITLE
Adds partitioner to configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Support for `partitioner` configuration. (#268)
+
 ## racecar v1.2.1
 
 * Require king_konf v1.0 or higher.

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ NOTE: `sasl_oauth_token_provider` only works using the `config/racecar.rb` confi
 These settings are related to consumers that _produce messages to Kafka_.
 
 * `producer_compression_codec` – If defined, Racecar will compress messages before writing them to Kafka. The codec needs to be one of `gzip`, `lz4`, or `snappy`, either as a Symbol or a String.
+* `partitioner` - The algorithm used to calculate message destination partitions. `crc32` is the default, `murmur2` is also supported. Can be passed as symbol or a string.
 
 #### Datadog monitoring
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -115,6 +115,9 @@ module Racecar
     desc "The codec used to compress messages with"
     symbol :producer_compression_codec
 
+    desc "The partitioner used to calculate message destination partition"
+    symbol :partitioner, default: :crc32, allowed_values: [:crc32, :murmur2]
+
     desc "Enable Datadog metrics"
     boolean :datadog_enabled, default: false
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -36,7 +36,8 @@ module Racecar
         sasl_oauth_token_provider: config.sasl_oauth_token_provider,
         sasl_over_ssl: config.sasl_over_ssl,
         ssl_ca_certs_from_system: config.ssl_ca_certs_from_system,
-        ssl_verify_hostname: config.ssl_verify_hostname
+        ssl_verify_hostname: config.ssl_verify_hostname,
+        partitioner: Kafka::Partitioner.new(hash_function: config.partitioner)
       )
 
       @consumer = kafka.consumer(


### PR DESCRIPTION
Adds `partitioner` to configuration for Racecar v1, allowing https://github.com/zendesk/ruby-kafka/pull/884 to be used.

@dasch 