### PR TITLE
Allow Consumer (Processor?) to overwrite global `fetch_messages` config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* `fetch_messages` can be configured per consumer, just as the maximum timeout to wait for a full batch.
+
 ## v2.4.0
 
 * Update librdkafka version from 1.4.0 to 1.5.0 by upgrading from rdkafka 0.8.0 to 0.10.0. ([#263](https://github.com/zendesk/racecar/pull/263))

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ end
 
 #### Batches
 
-- `fetch_messages` - The number of messages to fetch in a single batch. This can we set on a per consumer basis.
+- `fetch_messages` - The number of messages to fetch in a single batch. This can be set on a per consumer basis.
 
 #### Logging
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ end
 - `group_id` – The group id to use for a given group of consumers. Note that this _must_ be different for each consumer class. If left blank a group id is generated based on the consumer class name such that (for example) a consumer with the class name `BaconConsumer` would default to a group id of `bacon-consumer`.
 - `group_id_prefix` – A prefix used when generating consumer group names. For instance, if you set the prefix to be `kevin.` and your consumer class is named `BaconConsumer`, the resulting consumer group will be named `kevin.bacon-consumer`.
 
+#### Batches
+
+- `fetch_messages` - The number of messages to fetch in a single batch. This can we set on a per consumer basis.
+
 #### Logging
 
 - `logfile` – A filename that log messages should be written to. Default is `nil`, which means logs will be written to standard output.

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -223,6 +223,7 @@ module Racecar
       self.parallel_workers = consumer_class.parallel_workers
       self.subscriptions = consumer_class.subscriptions
       self.max_wait_time = consumer_class.max_wait_time || self.max_wait_time
+      self.fetch_messages = consumer_class.fetch_messages || self.fetch_messages
       self.pidfile ||= "#{group_id}.pid"
     end
 

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -9,7 +9,7 @@ module Racecar
     class << self
       attr_accessor :max_wait_time
       attr_accessor :group_id
-      attr_accessor :producer, :consumer, :parallel_workers
+      attr_accessor :producer, :consumer, :parallel_workers, :fetch_messages
 
       def subscriptions
         @subscriptions ||= []

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Racecar::Config do
 
   describe "#load_consumer_class" do
     let(:consumer_class) {
-      OpenStruct.new(group_id: nil, name: "DoStuffConsumer", subscriptions: [])
+      OpenStruct.new(group_id: nil, fetch_messages: nil, name: "DoStuffConsumer", subscriptions: [])
     }
 
     it "sets the group id if one has been explicitly defined" do
@@ -112,16 +112,27 @@ RSpec.describe Racecar::Config do
       expect(config.subscriptions).to eq ["one", "two"]
     end
 
+    it "sets the fetch_messages to the one defined on the consumer class" do
+      consumer_class.fetch_messages = 10
+
+      config.load_consumer_class(consumer_class)
+
+      expect(config.fetch_messages).to eq 10
+    end
+
     it "doesn't override existing values if the consumer hasn't specified anything" do
       consumer_class.max_wait_time = nil
       consumer_class.group_id = nil
+      consumer_class.fetch_messages = nil
 
       config.max_wait_time = 10
       config.group_id = "cats"
+      config.fetch_messages = 100
       config.load_consumer_class(consumer_class)
 
       expect(config.max_wait_time).to eq 10
       expect(config.group_id).to eq "cats"
+      expect(config.fetch_messages).to eq 100
     end
   end
 


### PR DESCRIPTION
Consumers might have different batch needs.