### PR TITLE
bump rdkafka dependency to 0.11.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.4.0)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.10.0)
+      rdkafka (~> 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -22,16 +22,16 @@ GEM
       concurrent-ruby (~> 1.0)
     king_konf (1.0.0)
     method_source (1.0.0)
-    mini_portile2 (2.7.0)
+    mini_portile2 (2.7.1)
     minitest (5.14.4)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rake (13.0.1)
-    rdkafka (0.10.0)
-      ffi (~> 1.9)
-      mini_portile2 (~> 2.1)
-      rake (>= 12.3)
+    rake (13.0.6)
+    rdkafka (0.11.0)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.7)
+      rake (> 12)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.10.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.11.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry"


### PR DESCRIPTION
rdkafka 0.11 uses librdkafka 1.7.0 which has a number of fixes in place (compared to 1.5.0) related to commit sync handling. 

Putting this up for early review and some feedback on whether this is a version update that we can do without risking backward compatibility issues. 