### PR TITLE
bugfix: increment attempts counter in integration_helper

### DIFF
--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -50,6 +50,7 @@ module IntegrationHelper
 
     while incoming_messages.count < expected_message_count && attempts < 20
       $stderr.puts "Waiting for messages..."
+      attempts += 1
 
       while (message = rdkafka_consumer.poll(1000))
         $stderr.puts "Received message #{message}"


### PR DESCRIPTION
## What

Increment attempts counter in integration_helper

## Why

Prevent `wait_for_messages` from looping forever if a message is not published