### PR TITLE
[INGEST-76] Updating to librdkafka 1.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ["2.4", "2.5", "2.6", "3.0"]
+        ruby-version: ["2.6", "3.0"]
 
     steps:
     - uses: zendesk/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * `fetch_messages` can be configured per consumer, just as the maximum timeout to wait for a full batch.
 
+## v2.4.1
+* Update librdkafka version from 1.5.0 to 1.8.2 by upgrading from rdkafka 0.10.0 to 0.11.0. ([#274](https://github.com/zendesk/racecar/pull/274))
+
 ## v2.4.0
 
 * Update librdkafka version from 1.4.0 to 1.5.0 by upgrading from rdkafka 0.8.0 to 0.10.0. ([#263](https://github.com/zendesk/racecar/pull/263))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    racecar (2.4.0)
+    racecar (2.4.1)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.10.0)
+      rdkafka (~> 0.11.1)
 
 GEM
   remote: https://rubygems.org/
@@ -17,21 +17,21 @@ GEM
     concurrent-ruby (1.1.9)
     diff-lcs (1.4.4)
     dogstatsd-ruby (5.2.0)
-    ffi (1.15.4)
+    ffi (1.15.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     king_konf (1.0.0)
     method_source (1.0.0)
-    mini_portile2 (2.7.0)
+    mini_portile2 (2.7.1)
     minitest (5.14.4)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.1)
-    rdkafka (0.10.0)
-      ffi (~> 1.9)
-      mini_portile2 (~> 2.1)
-      rake (>= 12.3)
+    rdkafka (0.11.1)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.6)
+      rake (> 12)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    racecar (2.4.1)
+    racecar (2.4.1.snapshot)
       king_konf (~> 1.0.0)
       rdkafka (~> 0.11.1)
 
@@ -64,4 +64,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.2.26
+   2.3.6

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Racecar
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Racecar
-  VERSION = "2.4.1"
+  VERSION = "2.4.1.snapshot"
 end

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
   spec.add_runtime_dependency "rdkafka",   "~> 0.11.1"

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.10.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.11.1"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry"


### PR DESCRIPTION
## Why?

My team (@zendesk/ingest) maintains the support views pipeline that uses Racecar. Our consumers hang often and never recover. As a first step, we would like to upgrade Racecar to use the latest for rdkafka-ruby (0.11.0) which upgrades  librdkafka to 1.8.2. Librdkafka 1.8.0 change log contains changes in this area.

### References:

- Librdkafka 1.8.0 release notes: https://github.com/edenhill/librdkafka/blob/cfc0731617ddd6858058f31f564772202f209e72/CHANGELOG.md#librdkafka-v180
- Librdkafka 1.8.2 release notes: https://github.com/edenhill/librdkafka/blob/cfc0731617ddd6858058f31f564772202f209e72/CHANGELOG.md#librdkafka-v182
- rdkafka-ruby PR upgrading to librdkafka 1.8.2: https://github.com/appsignal/rdkafka-ruby/pull/180

## How?

I made the following changes:

- Updated `racecar.gemspec` to require rdkafka 0.11.0
- Committed the changes to `Gemfile.lock` that were generated by running `bin/setup`

### Testing

I followed the instructions for setting up the Racecar development environment in the README and confirmed (dockerized) tests pass locally by running `docker-compose run --rm tests rspec`.

### Considerations

- I noticed that `spec/integration/consumer_spec.rb` tests only passed when ran in isolation. I observed this on both `master` and my branch.

Thanks in advance for your time! 🙇‍♀️ 