### PR TITLE
Allow producing to a specific partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add capability to specify partition number when producing messages
+
 ## v2.5.0
 
 * `fetch_messages` can be configured per consumer, just as the maximum timeout to wait for a full batch.

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -93,13 +93,14 @@ module Racecar
     protected
 
     # https://github.com/appsignal/rdkafka-ruby#producing-messages
-    def produce(payload, topic:, key: nil, partition_key: nil, headers: nil, create_time: nil)
+    def produce(payload, topic:, key: nil, partition: nil, partition_key: nil, headers: nil, create_time: nil)
       @delivery_handles ||= []
       message_size = payload.respond_to?(:bytesize) ? payload.bytesize : 0
       instrumentation_payload = {
         value: payload,
         headers: headers,
         key: key,
+        partition: partition,
         partition_key: partition_key,
         topic: topic,
         message_size: message_size,
@@ -112,6 +113,7 @@ module Racecar
           topic: topic,
           payload: payload,
           key: key,
+          partition: partition,
           partition_key: partition_key,
           timestamp: create_time,
           headers: headers,

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -168,7 +168,7 @@ class FakeProducer
     @delivery_callback = nil
   end
 
-  def produce(payload:, topic:, key:, partition_key: nil, timestamp: nil, headers: nil)
+  def produce(payload:, topic:, key:, partition: nil, partition_key: nil, timestamp: nil, headers: nil)
     @buffer << FakeRdkafka::FakeMessage.new(payload, key, topic, 0, 0, timestamp, headers)
     FakeDeliveryHandle.new(@kafka, @buffer.last, @delivery_callback)
   end


### PR DESCRIPTION
Allow producing to a specific partition.

I have encountered a use case where I want to produce a message (a tombstone, to be specific) to the same partition a consumed message came from.

Unfortunately, there's no guarantee the consumed message was produced using the same partitioner used by Rdkafka, or the one specified by the producing consumer.

Rdkafka already allows to specify a specific partition to produce a message to, so these changes are only passing the partition provided by the Racecar API 