### PR TITLE
Upgrades rdkafka gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ["2.4", "2.5", "2.6", "3.0"]
+        ruby-version: ["2.6", "3.0"]
 
     steps:
     - uses: zendesk/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Update librdkafka version from 1.5.0 to 1.8.2 by upgrading from rdkafka 0.10.0 to 0.11.1. ([#283](https://github.com/zendesk/racecar/pull/283))
+
 ## v2.6.0
 
 * Add capability to specify partition number when producing messages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.6.0)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.10.0)
+      rdkafka (~> 0.11.1)
 
 GEM
   remote: https://rubygems.org/
@@ -28,10 +28,10 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.1)
-    rdkafka (0.10.0)
-      ffi (~> 1.9)
-      mini_portile2 (~> 2.1)
-      rake (>= 12.3)
+    rdkafka (0.11.1)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.6)
+      rake (> 12)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -64,4 +64,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.3.0
+   2.3.7

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
   spec.add_runtime_dependency "rdkafka",   "~> 0.11.1"

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.10.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.11.1"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Originally created here https://github.com/zendesk/racecar/pull/274

### Description

This upgrade will require us to remove support from ruby 2.4 and 2.5, given that [the rdkafka gem](https://github.com/appsignal/rdkafka-ruby) dropped support for these versions in the [latest upgrade](https://github.com/appsignal/rdkafka-ruby/blob/main/CHANGELOG.md#0110).

This PR upgrades Racecar to use version[ 0.11.1 of the rdkafka gem](https://rubygems.org/gems/rdkafka/versions/0.11.1) which bumps the Librdkafka library to the version 1.8.2 ([release notes](https://github.com/edenhill/librdkafka/blob/cfc0731617ddd6858058f31f564772202f209e72/CHANGELOG.md#librdkafka-v182
)).

The main benefit of this upgrade is to try to address some issues with hanging consumers. [librdkafka 1.8.0 release notes](https://github.com/edenhill/librdkafka/blob/cfc0731617ddd6858058f31f564772202f209e72/CHANGELOG.md#librdkafka-v180) describe a couple fixes that had been done in regards to that.