### PR TITLE
updates rdkafka gem to 0.12.0.beta.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.7.0)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.11.1)
+      rdkafka (~> 0.12.0.beta.1)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +28,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.1)
-    rdkafka (0.11.1)
+    rdkafka (0.12.0.beta.1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.11.1"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.12.0.beta.1"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Updates rdkafka-ruby to version 0.12.0.beta.1.

This version uses Librdkafka version v1.9.0-RC1 which contains several fixes https://github.com/edenhill/librdkafka/blob/v1.9.0-PRE9/CHANGELOG.md#librdkafka-v190

One of the very exciting ones being
* Fix hang in `rd_kafka_list_groups()` if there are no available brokers
   to connect to ([#3705](https://github.com/edenhill/librdkafka/issues/3705)).


