### PR TITLE
update rdkafka to 0.12.0.beta.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.8.0.beta.1)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.12.0.beta.1)
+      rdkafka (~> 0.12.0.beta.3)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +28,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.1)
-    rdkafka (0.12.0.beta.1)
+    rdkafka (0.12.0.beta.3)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.12.0.beta.1"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.12.0.beta.3"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Updates `rdkafka-ruby` to `0.12.0.beta.3` which has ben updated to use librdkafka 1.9.0.RC2 with the following changes:

https://github.com/edenhill/librdkafka/compare/v1.9.0-RC1...v1.9.0-RC2