### PR TITLE
Replace colons in group ID with dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Replace colons in consumer group IDs with dashes.
+
 ## v2.8.0
 * Update librdkafka version from 1.8.2 to 1.9.0 by upgrading from rdkafka 0.10.0 to 0.12.0. ([#283](https://github.com/zendesk/racecar/pull/286))
 

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -216,8 +216,8 @@ module Racecar
         # Configurable and optional prefix:
         group_id_prefix,
 
-        # MyFunnyConsumer => my-funny-consumer
-        consumer_class.name.gsub(/[a-z][A-Z]/) { |str| "#{str[0]}-#{str[1]}" }.downcase,
+        # My::FunnyConsumer => my-funny-consumer
+        consumer_class.name.gsub(/[a-z][A-Z]/) { |str| "#{str[0]}-#{str[1]}" }.gsub(/:+/, '-').downcase,
       ].compact.join
 
       self.parallel_workers = consumer_class.parallel_workers

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Racecar::Config do
 
   describe "#load_consumer_class" do
     let(:consumer_class) {
-      OpenStruct.new(group_id: nil, fetch_messages: nil, name: "DoStuffConsumer", subscriptions: [])
+      OpenStruct.new(group_id: nil, fetch_messages: nil, name: "Do::StuffConsumer", subscriptions: [])
     }
 
     it "sets the group id if one has been explicitly defined" do


### PR DESCRIPTION
Hi. I have recent been encountering an issue when using Racecar with AWS MSK. Whenever I use a consumer class which is not namespaced (e.g. `MyFunnyConsumer`), everything works fine, however, if I use a consumer class which is namespace, (e.g. `MyFunny::Consumer`), I no longer am able to see Cloudwatch metrics for that consumer group.

From some testing it seems like it is due to the `:` in the group ID. I see some logic exists to format the group ID, however it seems limited to handling camel case. In my example here, the `MyFunny::Consumer` class is transformed into a group ID of `my-funny::consumer`.

https://github.com/zendesk/racecar/blob/73f424f36324f4161f820f6558097a704cbb3316/lib/racecar/config.rb#L219-L220

Now, I now my use case here, and the issue I am seeing, is limited to a proprietary Kafka implementation. However, I believe colons may be illegal characters for Kafka group IDs. I have struggled to find canonical documentation around this, but I have come across some related documentation:

> In the Consumer group ID property, specify the ID of the consumer group to which this consumer belongs. This ID can be up to 255 characters in length, and can include the following characters: a-z, A-Z, 0-9, . (dot), _ (underscore), and - (dash).

From: https://www.ibm.com/docs/en/app-connect/11.0.0?topic=enterprise-consuming-messages-from-kafka-topics

>  It's possible cause errors thrown in kafka broker when defining client id with invalid characters. The invalid characters I have tested are ?:,".

From: https://github.com/SOHU-Co/kafka-node/issues/394

I can understand if there may be something I'm overlooking, or that the current behaviour is the desired behaviour - but I thought I'd open a quick PR in case this is valid.