### PR TITLE
RD_KAFKA_RESP_ERR__STATE error

### DIFF
--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -49,6 +49,9 @@ module Racecar
 
     def store_offset(message)
       current.store_offset(message)
+    rescue Rdkafka::RdkafkaError => e
+      raise ErroneousStateError.new(e) if e.code == :state # -172
+      raise e
     end
 
     def commit

--- a/lib/racecar/erroneous_state_error.rb
+++ b/lib/racecar/erroneous_state_error.rb
@@ -1,0 +1,34 @@
+# `rd_kafka_offsets_store()` (et.al) returns an error for any
+# partition that is not currently assigned (through `rd_kafka_*assign()`).
+# This prevents a race condition where an application would store offsets
+# after the assigned partitions had been revoked (which resets the stored
+# offset), that could cause these old stored offsets to be committed later
+# when the same partitions were assigned to this consumer again - effectively
+# overwriting any committed offsets by any consumers that were assigned the
+# same partitions previously. This would typically result in the offsets
+# rewinding and messages to be reprocessed.
+# As an extra effort to avoid this situation the stored offset is now
+# also reset when partitions are assigned (through `rd_kafka_*assign()`).
+module Racecar
+  class ErroneousStateError < StandardError
+    def initialize(rdkafka_error)
+      raise rdkafka_error unless rdkafka_error.is_a?(Rdkafka::RdkafkaError)
+
+      @rdkafka_error = rdkafka_error
+    end
+
+    attr_reader :rdkafka_error
+
+    def code
+      @rdkafka_error.code
+    end
+
+    def to_s
+      <<~EOM
+        Partition is no longer assigned to this consumer and the offset could not be stored for commit:
+        #{@rdkafka_error.to_s}
+      EOM
+    end
+
+  end
+end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -4,6 +4,7 @@ require "rdkafka"
 require "racecar/pause"
 require "racecar/message"
 require "racecar/message_delivery_error"
+require "racecar/erroneous_state_error"
 
 module Racecar
   class Runner

--- a/spec/consumer_set_spec.rb
+++ b/spec/consumer_set_spec.rb
@@ -242,6 +242,18 @@ RSpec.describe Racecar::ConsumerSet do
         end
       end
 
+      describe "#store_offset" do
+        it "raises ErroneousStateError when RD_KAFKA_RESP_ERR__STATE(-172) is raised" do
+          allow(rdconsumer).to receive(:store_offset).with(:message).and_raise(Rdkafka::RdkafkaError, -172) # state
+          expect {consumer_set.store_offset(:message) }.to raise_error(Racecar::ErroneousStateError)
+        end
+
+        it "raises other rdkafka errors" do
+          allow(rdconsumer).to receive(:store_offset).with(:message).and_raise(Rdkafka::RdkafkaError, -1)
+          expect {consumer_set.store_offset(:message) }.to raise_error(Rdkafka::RdkafkaError)
+        end
+      end
+
       describe "#commit" do
         it "forwards to Rdkafka" do
           expect(rdconsumer).to receive(:commit).once


### PR DESCRIPTION
librdkafka `rd_kafka_offsets_store()` (et.al) will now return an error for any  partition that is not currently assigned (through `rd_kafka_*assign()`). This PR aims to give more context to the error when it happens.