### PR TITLE
warn when partition is not assigned to consumer

### DIFF
--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -50,7 +50,10 @@ module Racecar
     def store_offset(message)
       current.store_offset(message)
     rescue Rdkafka::RdkafkaError => e
-      raise ErroneousStateError.new(e) if e.code == :state # -172
+      if e.code == :state # -172
+        @logger.warn "Attempted to store_offset, but we're not subscribed to it: #{ErroneousStateError.new(e)}"
+        return
+      end
       raise e
     end
 

--- a/lib/racecar/erroneous_state_error.rb
+++ b/lib/racecar/erroneous_state_error.rb
@@ -25,7 +25,7 @@ module Racecar
 
     def to_s
       <<~EOM
-        Partition is no longer assigned to this consumer and the offset could not be stored for commit:
+        Partition is no longer assigned to this consumer and the offset could not be stored for commit.
         #{@rdkafka_error.to_s}
       EOM
     end

--- a/spec/consumer_set_spec.rb
+++ b/spec/consumer_set_spec.rb
@@ -243,9 +243,11 @@ RSpec.describe Racecar::ConsumerSet do
       end
 
       describe "#store_offset" do
-        it "raises ErroneousStateError when RD_KAFKA_RESP_ERR__STATE(-172) is raised" do
+        it "raises ErroneousStateError when RD_KAFKA_RESP_ERR__STATE(-172) is not raised" do
+          allow(logger).to receive(:warn)
           allow(rdconsumer).to receive(:store_offset).with(:message).and_raise(Rdkafka::RdkafkaError, -172) # state
-          expect {consumer_set.store_offset(:message) }.to raise_error(Racecar::ErroneousStateError)
+          expect {consumer_set.store_offset(:message) }.not_to raise_error(Racecar::ErroneousStateError)
+          expect(logger).to have_received(:warn)
         end
 
         it "raises other rdkafka errors" do


### PR DESCRIPTION
Consumer sometimes lose their assigned partition and errors when trying to store the offset.
```
WARN Racecar::ErroneousStateError Partition is no longer assigned to this consumer and the offset could not be stored for commit:
Local: Erroneous state (state)

ERROR Failed to process topic_name/partition_number at offset_start..offset_end: Partition is no longer assigned to this consumer and the offset could not be stored for commit:
Local: Erroneous state (state)

INFO Attempted to pause topic_name/partition_number, but we're not subscribed to it
```
This is caused by a change in librdkafka where consumers that call `rd_kafka_offsets_store()` (et.al) will now return an error for any partition that is not currently assigned (through rd_kafka_*assign()).

Because this is a somewhat expected behaviour I believe that a WARN level is more appropriate.