### PR TITLE
Expose partitioner config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Add `partitioner` producer config option to allow changing the strategy to
+  determine which topic partition a message is written to when racecar
+  produces a kafka message
+
 ## v2.8.2
 * Handles ErroneousStateError, in previous versions the consumer would do several unecessary group leave/joins. The log level is also changed to WARN instead of ERROR. ([#295](https://github.com/zendesk/racecar/pull/295))
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Racecar has support for using SASL to authenticate clients using either the GSSA
 
 These settings are related to consumers that _produce messages to Kafka_.
 
+- `partitioner` – The strategy used to determine which topic partition a message is written to when Racecar produces a value to Kafka. The codec needs to be one of `consistent`, `consistent_random` `murmur2` `murmur2_random` `fnv1a` `fnv1a_random` either as a Symbol or a String, defaults to `consistent_random`
 - `producer_compression_codec` – If defined, Racecar will compress messages before writing them to Kafka. The codec needs to be one of `gzip`, `lz4`, or `snappy`, either as a Symbol or a String.
 
 #### Datadog monitoring

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -77,6 +77,9 @@ module Racecar
     desc "The log level for the Racecar logs"
     string :log_level, default: "info"
 
+    desc "The strategy used to determine which topic partition a message is written to when Racecar produces a value to Kafka; defaults to `consistent_random`"
+    symbol :partitioner, allowed_values: %i{consistent consistent_random murmur2 murmur2_random fnv1a fnv1a_random}, default: :consistent_random
+
     desc "Protocol used to communicate with brokers"
     symbol :security_protocol, allowed_values: %i{plaintext ssl sasl_plaintext sasl_ssl}
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -149,7 +149,9 @@ module Racecar
         "client.id"              => config.client_id,
         "statistics.interval.ms" => config.statistics_interval_ms,
         "message.timeout.ms"     => config.message_timeout * 1000,
+        "partitioner"            => config.partitioner.to_s,
       }
+
       producer_config["compression.codec"] = config.producer_compression_codec.to_s unless config.producer_compression_codec.nil?
       producer_config.merge!(config.rdkafka_producer)
       producer_config

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -40,6 +40,27 @@ RSpec.describe Racecar::Config do
     }.to raise_exception(KingKonf::ConfigError)
   end
 
+  it "requires `partitioner` to be a valid value" do
+    expect {
+      config.partitioner = :consistent
+      config.partitioner = :consistent_random
+      config.partitioner = :murmur2
+      config.partitioner = :murmur2_random
+      config.partitioner = :fnv1a
+      config.partitioner = :fnv1a_random
+      config.partitioner = "consistent"
+      config.partitioner = "consistent_random"
+      config.partitioner = "murmur2"
+      config.partitioner = "murmur2_random"
+      config.partitioner = "fnv1a"
+      config.partitioner = "fnv1a_random"
+    }.not_to raise_exception
+
+    expect {
+      config.partitioner = "abc"
+    }.to raise_exception(KingKonf::ConfigError)
+  end
+
   it "requires `security_protocol` to be a valid" do
     expect {
       config.security_protocol = :plaintext


### PR DESCRIPTION
librdkafka allows different strategies to determine the partitions.
https://docs.confluent.io/5.1.4/clients/librdkafka/CONFIGURATION_8md.html

This PR exposes `partitioner` as an option that can be directly used instead of
using the `producer` config option