### PR TITLE
Add built-in health check functionality for systems like Kubernetes

### DIFF
--- a/bin/health-check
+++ b/bin/health-check
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+path=$HEARTBEAT_FILE_PATH
+heartbeat_interval=$HEARTBEAT_TIMEOUT
+
+if [ -z "$path" ]
+then
+  echo "ENV var HEARTBEAT_FILE_PATH not specified!" 1>&2
+  exit 1
+fi
+
+if ! [ -f "$path" ]
+then
+  echo "Racecar heartbeat file $path not found; health check failed!" 1>&2
+  exit 1
+fi
+
+if [ $(find "$path" -mtime +"$heartbeat_interval") ]
+then
+  echo "Racecar heartbeat in $path is more than $heartbeat_interval old; health check failed!" 1>&2
+  exit 1
+else
+  echo "Racecar heartbeat detected in $path; health check succeeded!" 1>&2
+  exit 0
+fi

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -167,6 +167,9 @@ module Racecar
           for backward compatibility, however this can be quite memory intensive"
     integer :statistics_interval, default: 1
 
+    desc "Path to heartbeat file"
+    string :heartbeat_file_path
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "rdkafka"
 require "racecar/pause"
 require "racecar/message"
@@ -68,6 +69,10 @@ module Racecar
         break if @stop_requested
         resume_paused_partitions
         @instrumenter.instrument("main_loop", instrumentation_payload) do
+          if @config.heartbeat_file_path
+            FileUtils.touch(@config.heartbeat_file_path)
+          end
+
           case process_method
           when :batch then
             msg_per_part = consumer.batch_poll(config.max_wait_time_ms).group_by(&:partition)


### PR DESCRIPTION
#### Description

We want to integrate the racecar consumer health-check readiness probe into racecar itself. As a result, the health check functionality will be part of racecar so that racecar users do not need to implement the logic as well as the bash scripts by themselves. In another word, to check the heathiness of racecar, the racecar users only need to include the built-in probe in there K8s manifest.

The readiness probe touches the file to update the creation timestamp in every iteration of the racecar main loop. When the racecar is down, the timestamp gets expired so that the readiness probe which checks the timestamp fails.

We also need to update the handbook of racecar to introduce how to make use of the integrated readiness probe. The probe is a bash script and two env vars are needed.

[edit: description provided by @BingkunWu]