### PR TITLE
update File exist method call since exists is deprecated in Ruby 3.2

### DIFF
--- a/lib/racecar/daemon.rb
+++ b/lib/racecar/daemon.rb
@@ -54,7 +54,7 @@ module Racecar
     end
 
     def pid
-      if File.exists?(pidfile)
+      if File.exist?(pidfile)
         File.read(pidfile).to_i
       else
         nil
@@ -89,7 +89,7 @@ module Racecar
       end
 
       at_exit do
-        File.delete(pidfile) if File.exists?(pidfile)
+        File.delete(pidfile) if File.exist?(pidfile)
       end
     rescue Errno::EEXIST
       check_pid


### PR DESCRIPTION
File.exists? has been deprecated since Ruby 2.2 and has been removed in Ruby 3.2

Please see: https://bugs.ruby-lang.org/issues/17391

