### PR TITLE
Update racecar v2 batch processing example

### DIFF
--- a/examples/batch_consumer.rb
+++ b/examples/batch_consumer.rb
@@ -3,8 +3,8 @@
 class BatchConsumer < Racecar::Consumer
   subscribes_to "messages", start_from_beginning: false
 
-  def process_batch(batch)
-    batch.messages.each do |message|
+  def process_batch(messages)
+    messages.each do |message|
       puts message.value
     end
   end


### PR DESCRIPTION
The example for batch processing is outdated for v2 since `process_batch`
receives an array of messages rather than a batch struct

```
bundle exec racecar --require examples/batch_consumer BatchConsumer
=> Starting Racecar consumer BatchConsumer...
=> Wrooooom!
=> Ctrl-C to shutdown consumer
W, [2023-01-19T14:28:58.314843 #65618]  WARN -- : ActiveSupport::Notifications not available, instrumentation is disabled
E, [2023-01-19T14:29:01.338999 #65618] ERROR -- : Failed to process messages/0 at 25004..25005: undefined method `messages' for [#<Racecar::Message:0x00000001065a3aa0 @rdkafka_message=#<Rdkafka::Consumer::Message:0x00000001065a8de8 @topic="messages", @partition=0, @payload="Payload 0", @key="Key 0", @offset=25004, @timestamp=2023-01-19 14:29:00.513 +0100, @headers={}>, @retries_count=0>, #<Racecar::Message:0x00000001065a3a28 @rdkafka_message=#<Rdkafka::Consumer::Message:0x00000001065a86b8 @topic="messages", @partition=0, @payload="Payload 1", @key="Key 1", @offset=25005, @timestamp=2023-01-19 14:29:00.513 +0100, @headers={}>, @retries_count=0>]:Array

    batch.messages.each do |message|
         ^^^^^^^^^
W, [2023-01-19T14:29:01.339057 #65618]  WARN -- : Pausing partition messages/0 for 10.0 seconds
```