### PR TITLE
Event based Kubernetes liveness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `partitioner` producer config option to allow changing the strategy to
   determine which topic partition a message is written to when racecar
   produces a kafka message
+* Add built-in liveness probe for Kubernetes deployments.
 
 ## v2.8.2
 * Handles ErroneousStateError, in previous versions the consumer would do several unecessary group leave/joins. The log level is also changed to WARN instead of ERROR. ([#295](https://github.com/zendesk/racecar/pull/295))

--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -62,19 +62,11 @@ module Racecar
   end
 
   def self.instrumenter
-    @instrumenter ||= begin
-      default_payload = { client_id: config.client_id, group_id: config.group_id }
-
-      Instrumenter.new(default_payload).tap do |instrumenter|
-        if instrumenter.backend == NullInstrumenter
-          logger.warn "ActiveSupport::Notifications not available, instrumentation is disabled"
-        end
-      end
-    end
+    config.instrumenter
   end
 
   def self.run(processor)
-    runner = Runner.new(processor, config: config, logger: logger, instrumenter: instrumenter)
+    runner = Runner.new(processor, config: config, logger: logger, instrumenter: config.instrumenter)
 
     if config.parallel_workers && config.parallel_workers > 1
       ParallelRunner.new(runner: runner, config: config, logger: logger).run

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -5,6 +5,7 @@ require "logger"
 require "fileutils"
 require "racecar/rails_config_file_loader"
 require "racecar/daemon"
+require "racecar/liveness_probe"
 
 module Racecar
   class Cli
@@ -56,6 +57,11 @@ module Racecar
         daemonize!
       else
         $stderr.puts "=> Ctrl-C to shutdown consumer"
+      end
+
+      if config.liveness_probe_enabled
+        $stderr.puts "=> Liveness probe enabled"
+        config.install_liveness_probe
       end
 
       processor = consumer_class.new

--- a/lib/racecar/ctl.rb
+++ b/lib/racecar/ctl.rb
@@ -32,6 +32,17 @@ module Racecar
       @command = command
     end
 
+    def liveness_probe(args)
+      require "racecar/liveness_probe"
+      parse_options!(args)
+
+      if ENV["RAILS_ENV"]
+        Racecar.config.load_file("config/racecar.yml", ENV["RAILS_ENV"])
+      end
+
+      Racecar.config.liveness_probe.check_liveness_within_interval!
+    end
+
     def status(args)
       parse_options!(args)
 

--- a/lib/racecar/instrumenter.rb
+++ b/lib/racecar/instrumenter.rb
@@ -9,16 +9,9 @@ module Racecar
     NAMESPACE = "racecar"
     attr_reader :backend
 
-    def initialize(default_payload = {})
+    def initialize(backend:, default_payload: {})
+      @backend = backend
       @default_payload = default_payload
-
-      @backend = if defined?(ActiveSupport::Notifications)
-        # ActiveSupport needs `concurrent-ruby` but doesn't `require` it.
-        require 'concurrent/utility/monotonic_time'
-        ActiveSupport::Notifications
-      else
-        NullInstrumenter
-      end
     end
 
     def instrument(event_name, payload = {}, &block)

--- a/lib/racecar/liveness_probe.rb
+++ b/lib/racecar/liveness_probe.rb
@@ -1,0 +1,78 @@
+require "fileutils"
+
+module Racecar
+  class LivenessProbe
+    def initialize(message_bus, file_path, max_interval)
+      @message_bus = message_bus
+      @file_path = file_path
+      @max_interval = max_interval
+      @subscribers = []
+    end
+
+    attr_reader :message_bus, :file_path, :max_interval, :subscribers
+    private     :message_bus, :file_path, :max_interval, :subscribers
+
+    def check_liveness_within_interval!
+      unless liveness_event_within_interval?
+        $stderr.puts "Racecar healthcheck failed: No liveness within interval #{max_interval}s. Last liveness at #{last_liveness_event_at}, #{elapsed_since_liveness_event} seconds ago."
+        Process.exit(1)
+      end
+    end
+
+    def liveness_event_within_interval?
+      elapsed_since_liveness_event < max_interval
+    rescue Errno::ENOENT
+      $stderr.puts "Racecar healthcheck failed: Liveness file not found `#{file_path}`"
+      Process.exit(1)
+    end
+
+    def install
+      unless file_path && file_writeable?
+        raise(
+          "Liveness probe configuration error: `liveness_probe_file_path` must be set to a writable file path.\n" \
+            "  Set `RACECAR_LIVENESS_PROBE_FILE_PATH` and `RACECAR_LIVENESS_MAX_INTERVAL` environment variables."
+        )
+      end
+
+      subscribers << message_bus.subscribe("start_main_loop.racecar") do
+        touch_liveness_file
+      end
+
+      subscribers = message_bus.subscribe("shut_down.racecar") do
+        delete_liveness_file
+      end
+
+      nil
+    end
+
+    def uninstall
+      subscribers.each { |s| message_bus.unsubscribe(s) }
+    end
+
+    private
+
+    def elapsed_since_liveness_event
+      Time.now - last_liveness_event_at
+    end
+
+    def last_liveness_event_at
+      File.mtime(file_path)
+    end
+
+    def touch_liveness_file
+      FileUtils.touch(file_path)
+    end
+
+    def delete_liveness_file
+      FileUtils.rm_rf(file_path)
+    end
+
+    def file_writeable?
+      File.write(file_path, "")
+      File.unlink(file_path)
+      true
+    rescue
+      false
+    end
+  end
+end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -67,6 +67,8 @@ module Racecar
       loop do
         break if @stop_requested
         resume_paused_partitions
+
+        @instrumenter.instrument("start_main_loop", instrumentation_payload)
         @instrumenter.instrument("main_loop", instrumentation_payload) do
           case process_method
           when :batch then
@@ -94,6 +96,7 @@ module Racecar
     ensure
       producer.close
       Racecar::Datadog.close if Object.const_defined?("Racecar::Datadog")
+      @instrumenter.instrument("shut_down", instrumentation_payload || {})
     end
 
     def stop

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -253,4 +253,58 @@ RSpec.describe Racecar::Config do
       end
     end
   end
+
+  describe "#instrumenter" do
+    context "when ActiveSupport::Notifications is available" do
+      before { require "active_support/notifications" }
+
+      it "returns the 'real' instrumenter" do
+        expect(config.instrumenter).to be_a(Racecar::Instrumenter)
+      end
+    end
+
+    context "when ActiveSupport::Notifications is not available" do
+      before { hide_const("ActiveSupport::Notifications") }
+
+      it "returns the compatible null instrumenter singleton" do
+        expect(config.instrumenter).to be(Racecar::NullInstrumenter)
+      end
+
+      it "warns that instrumentation is disabled" do
+        expect(config.logger).to receive(:warn).with(/instrumentation is disabled/)
+
+        config.instrumenter
+      end
+    end
+  end
+
+  describe "#install_liveness_probe" do
+    it "delegates to LivenessProbe#install" do
+      expect(config.liveness_probe).to receive(:install)
+
+      config.install_liveness_probe
+    end
+  end
+
+  describe "#liveness_probe" do
+    it "returns the liveness probe" do
+      expect(config.liveness_probe).to be_a(Racecar::LivenessProbe)
+    end
+
+    it "returns the same LivenessProbe instance" do
+      expect(config.liveness_probe).to be(config.liveness_probe)
+    end
+
+    it "loads ActiveSupport::Notifications" do
+      expect(config).to receive(:require).with("active_support/notifications").and_call_original
+
+      config.liveness_probe
+    end
+
+    it "loads ActiveSupport::Notifications" do
+      expect(config).to receive(:require).with("active_support/notifications").and_call_original
+
+      config.liveness_probe
+    end
+  end
 end

--- a/spec/instrumenter_spec.rb
+++ b/spec/instrumenter_spec.rb
@@ -2,10 +2,11 @@
 
 RSpec.describe Racecar::Instrumenter do
   describe '#instrument' do
-    let(:instrumenter) { Racecar::Instrumenter.new }
+    let(:instrumenter) { Racecar::Instrumenter.new(backend: backend) }
+    let(:backend) { double(:backend, instrument: nil) }
 
     it 'applies a namespace' do
-      expect(instrumenter.backend).
+      expect(backend).
         to receive(:instrument).
         with('event.racecar', any_args)
 
@@ -13,7 +14,7 @@ RSpec.describe Racecar::Instrumenter do
     end
 
     it 'appends a default payload' do
-      expect(instrumenter.backend).
+      expect(backend).
         to receive(:instrument).
         with('event.racecar', client_id: 'race')
 

--- a/spec/integration/kubernetes_probes_spec.rb
+++ b/spec/integration/kubernetes_probes_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "timeout"
+require "securerandom"
+require "active_support/notifications"
+require "racecar/cli"
+
+RSpec.describe "kubernetes probes", type: :integration do
+  describe "liveness probe" do
+    before do
+      set_config
+      input_topic = generate_input_topic_name
+      consumer_class.subscribes_to(input_topic)
+    end
+
+    after do
+      stop_racecar
+      ensure_liveness_file_is_deleted
+      reset_notifications
+      restore_config
+    end
+
+    it "initially fails, then passes when the main loop starts" do
+      expect(Pathname.new(file_path)).not_to be_readable
+      expect(run_probe).to be false
+
+      start_racecar
+      wait_for_main_loop
+
+      expect(run_probe).to be true
+    end
+
+    it "fails if processing stalls for too long" do
+      start_racecar
+      wait_for_main_loop
+
+      expect(run_probe).to be true
+
+      stall_processing
+      sleep(max_interval * 1.1)
+
+      expect(run_probe).to be false
+    end
+
+    context "even when the timeout is long" do
+      let(:max_interval) { 10 }
+
+      it "fails immediately after stopping" do
+        start_racecar
+        wait_for_main_loop
+
+        stop_racecar
+
+        expect(run_probe).to be false
+      end
+    end
+
+    context "when the probe is disabled" do
+      before do
+        Racecar.config.liveness_probe_enabled = false
+      end
+
+      it "does not touch the file" do
+        start_racecar
+        wait_for_main_loop
+
+        liveness_file = Pathname.new(Racecar.config.liveness_probe_file_path)
+        expect(liveness_file).not_to be_readable
+      end
+    end
+
+    let(:file_path) { "/tmp/racecar-liveness-file-#{SecureRandom.hex(4)}" }
+    let(:max_interval) { 1 }
+    let(:racecar_cli) { Racecar::Cli.new([consumer_class.name.to_s]) }
+
+    let(:consumer_class) do
+      NoOpConsumer = Class.new(Racecar::Consumer) do
+        self.group_id = "schrödingers-consumers"
+
+        define_method :process do |_message|
+        end
+      end
+    end
+
+    let(:env_vars) do
+      {
+        "RACECAR_LIVENESS_PROBE_FILE_PATH" => file_path,
+        "RACECAR_LIVENESS_PROBE_MAX_INTERVAL" => max_interval.to_s,
+      }
+    end
+
+    def run_probe
+      command = "exe/racecarctl liveness_probe"
+      output, status = Open3.capture2e(env_vars, command)
+      $stderr.puts "Probe output: #{output}" if ENV["DEBUG"]
+      status.success?
+    end
+
+    def wait_for_main_loop
+      test_thread = Thread.current
+      execute_after_next_main_loop { test_thread.wakeup }
+      sleep_with_timeout
+    end
+
+    def stall_processing(time = 5)
+      execute_after_next_main_loop { sleep(time) }
+    end
+
+    def ensure_liveness_file_is_deleted
+      File.unlink(file_path) if File.exist?(file_path)
+    end
+  end
+
+  def start_racecar
+    @cli_run_thread = Thread.new do
+      Thread.current.name = "Racecar CLI"
+      racecar_cli.run
+    end
+  end
+
+  def stop_racecar
+    Process.kill("INT", Process.pid)
+    if @cli_run_thread.alive?
+      @cli_run_thread.wakeup
+      @cli_run_thread.join(2)
+      @cli_run_thread.terminate
+    end
+  end
+
+  def execute_after_next_main_loop(&block)
+    subscriber = ActiveSupport::Notifications.subscribe("main_loop.racecar") do |event, *_|
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+
+      block.call if block
+    end
+  end
+
+  def sleep_with_timeout(max_sleep = 8)
+    Timeout.timeout(max_sleep) { sleep }
+  end
+
+  def set_config
+    @original_config = Racecar.config
+    Racecar.config = Racecar::Config.new
+    Racecar.config.max_wait_time = 0.05
+    Racecar.config.liveness_probe_enabled = true
+    Racecar.config.liveness_probe_file_path = file_path
+    Racecar.config.liveness_probe_max_interval = max_interval
+  end
+
+  def restore_config
+    Racecar.config = @original_config
+  end
+
+  def reset_notifications
+    Racecar.config.liveness_probe.uninstall
+  end
+end

--- a/spec/liveness_probe_spec.rb
+++ b/spec/liveness_probe_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "racecar/liveness_probe"
+require "active_support/notifications"
+
+RSpec.describe Racecar::LivenessProbe do
+  subject(:probe) { Racecar::LivenessProbe.new(message_bus, file_path_string, max_interval) }
+
+  let(:file_path) { Pathname.new(file_path_string) }
+  let(:file_path_string) { "/tmp/liveness-probe-test-#{SecureRandom.hex(4)}" }
+  let(:max_interval) { 5 }
+  let(:message_bus) { ActiveSupport::Notifications }
+
+  after do
+    ActiveSupport::Notifications.notifier = ActiveSupport::Notifications::Fanout.new
+    FileUtils.rm_rf(file_path)
+    Process.waitall
+  end
+
+  describe "#check_liveness_within_interval!" do
+    context "when the file has just been touched" do
+      before do
+        FileUtils.touch(file_path_string)
+      end
+
+      it "does nothing, exits successfully" do
+        probe.check_liveness_within_interval!
+      end
+    end
+
+    context "when the file has not been touched since before max_interval seconds ago" do
+      before do
+        before_max_interval = Time.now - (max_interval + 1)
+        FileUtils.touch(file_path_string, mtime: before_max_interval)
+      end
+
+      it "exits the process with error status 1" do
+        expect(Process).to receive(:exit).with(1)
+
+        probe.check_liveness_within_interval!
+      end
+    end
+  end
+
+  describe "#install" do
+    context "when the file is writeable"  do
+      it "touches the file on 'start_main_loop'" do
+        probe.install
+
+        expect { message_bus.publish("start_main_loop.racecar") }.to(change { file_path.exist? }.from(false).to(true))
+      end
+
+      it "deletes the file on 'shut_down'" do
+        probe.install
+
+        FileUtils.touch(file_path)
+
+        expect { message_bus.publish("shut_down.racecar") }.to(change { file_path.exist? }.from(true).to(false))
+      end
+    end
+
+    context "when the file is not writable"  do
+      context "because the directory does not exist" do
+        let(:file_path_string) { "directory-does-not-exist/liveness-file" }
+
+        it "raises a helpful message" do
+          expect { probe.install }.to(raise_error(/Liveness probe configuration error/))
+        end
+      end
+
+      context "because the process does not have write permissions" do
+        let(:file_path_string) { "/etc" }
+
+        it "raises a helpful message" do
+          expect { probe.install }.to(raise_error(/Liveness probe configuration error/))
+        end
+      end
+    end
+  end
+
+  describe "#uninstall" do
+    before { probe.install }
+
+    it "stops the probe " do
+      probe.uninstall
+
+      expect(file_path).not_to exist
+    end
+
+    def trigger_probe
+      message_bus.instrument("start_main_loop.racecar")
+    end
+  end
+end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -244,8 +244,7 @@ end
 
 class FakeInstrumenter < Racecar::Instrumenter
   def initialize(*)
-    super
-    @backend = Racecar::NullInstrumenter
+    super(backend: Racecar::NullInstrumenter)
   end
 end
 

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "securerandom"
 require "open3"
 
 module IntegrationHelper

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -24,9 +24,9 @@ module IntegrationHelper
     messages.map do |m|
       rdkafka_producer.produce(
         topic: topic,
-        key: m.fetch(:key),
+        key: m.fetch(:key, nil),
         payload: m.fetch(:payload),
-        partition: m.fetch(:partition)
+        partition: m.fetch(:partition, nil),
       )
     end.each(&:wait)
 

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -28,9 +28,10 @@ module IntegrationHelper
         partition: m.fetch(:partition)
       )
     end.each(&:wait)
-    rdkafka_producer.close
 
     $stderr.puts "Published messages to topic: #{topic}; messages: #{messages}"
+  ensure
+    rdkafka_producer.close
   end
 
   def create_topic(topic:, partitions: 1)
@@ -57,6 +58,8 @@ module IntegrationHelper
         incoming_messages << message
       end
     end
+  ensure
+    rdkafka_consumer.close
   end
 
   def wait_for_assignments(group_id:, topic:, expected_members_count:)


### PR DESCRIPTION
This PR is functionally similar to @jbdietrich's PR #308 

The main loop of the runner touches a file and a script will exit 0 or 1 depending on whether it was touched recently enough.

Why this implementation?

- The health check is triggered by the in-built instrumentation events so doesn't clutter up the main loop code and is entirely optional.
- The 'probe' is a first class object, allowing for extensibility such as monitoring individual partition processing or rebalancing (#309)
- The script is written in Ruby, I think we agree we like more than bash and can spare the extra ~10ms of CPU to run it.
- There's some appealing refactoring and test fixes bundled with it.

This has been back-ported into Voice and will be deployed shortly. In testing it has achieved very smooth rolling deploys with minimal disruption to message processing.

After production deployment I'd be happy to update the k8s deployment section of the README.