### PR TITLE
use proper onomatopoeia when booting Racecar

### DIFF
--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -50,7 +50,7 @@ module Racecar
         configure_datadog
       end
 
-      $stderr.puts "=> Wrooooom!"
+      $stderr.puts "=> Vrooooom!"
 
       if config.daemonize
         daemonize!

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Racecar::Cli do
   context "displaying startup message" do
     before do
       expect($stderr).to receive(:puts).with(/Starting Racecar consumer CatConsumer/)
-      expect($stderr).to receive(:puts).with(/Wro+m!/)
+      expect($stderr).to receive(:puts).with(/Vro+m!/)
       expect($stderr).to receive(:puts).with(/Ctrl-C to shutdown consumer/)
     end
 


### PR DESCRIPTION
When a consumer process is initiated, we communicate to developers that Racecar is booting through a cute onomatopoeia.

Its not clear what model of car the developers of Racecar have (perhaps electric or some sort of scandinavian model), but according to wikipedia, the correct sound a car makes is "vrooom" not "wrooom": https://en.wikipedia.org/wiki/Vroom.

This PR modifies the sound to not break immersion for developers.