### PR TITLE
Bump rdkafka to 0.13.0.beta.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.8.2)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.12.0)
+      rdkafka (~> 0.13.0.beta.3)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +28,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.1)
-    rdkafka (0.12.0)
+    rdkafka (0.13.0.beta.3)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.12.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.13.0.beta.3"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Main changes from rdkafka-ruby changelog

* Bump librdkafka to 1.9.2 (thijsc) from 1.9.0
* Support cooperative sticky partition assignment in the rebalance callback (methodmissing)
* Support both string and symbol header keys (ColinDKelley)
* Handle tombstone messages properly (kgalieva)
* Add topic name to delivery report (maeve)
* Allow string partitioner config (mollyegibson)
* Fix documented type for DeliveryReport#error (jimmydo)
* Use finalizers to cleanly exit producer and admin (thijsc)

Full diff https://my.diffend.io/gems/rdkafka/0.12.0/0.13.0.beta.3

Changes in librdkafka

librdkafka v1.9.2

 * The SASL OAUTHBEAR OIDC POST field was sometimes truncated by one byte.
 * The bundled version of OpenSSL has been upgraded to version 1.1.1q for non-Windows builds. Windows builds remain on OpenSSL 1.1.1n for the time being.
 * The bundled version of Curl has been upgraded to version 7.84.0.

librdkafka v1.9.1

 * The librdkafka.redist NuGet package now contains OSX M1/arm64 builds.
 * Self-contained static libraries can now be built on OSX M1 too, thanks to
   disabling curl's configure runtime check.

Full diff https://github.com/confluentinc/librdkafka/compare/v1.9.0...v1.9.2