### PR TITLE
Add workflow for pushing to Ruby Gems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish Gem
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+    secrets:
+      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,9 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
+# Pushing to rubygems is handled by a github workflow
+ENV["gem_push"] = "false"
+
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec


### PR DESCRIPTION
Creates a workflow for publishing to the public Zendesk RubyGems account.

Uses the workflow from the public [`gw` action](https://github.com/zendesk/gw/blob/main/ruby-gem-publication/README.md).

To publish a new gem version, you still call `rake release`. It will:

1. Build the gem
2. Tag (if everything has been committed)
3. Push tag to the repo
4. ~Push the gem to rubygems~ Skipped (see below)

In the Rakefile, we set `gem_push` to `false`, so step (4) is skipped. Instead, the publish.yml workflow will be triggered by step (3), and you need to have someone approve the workflow run on https://github.com/zendesk/racecar/actions/workflows/publish.yml