### PR TITLE
Update ruby matrix for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ["2.6", "3.0"]
+        ruby-version: ["2.7", "3.0", "3.1"]
 
     steps:
     - uses: zendesk/checkout@v3


### PR DESCRIPTION
This PR will add 3.1 to our ruby version matrix and remove 2.6 since it's no
longer supported for a year now