### PR TITLE
Integration test performance and refactoring

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
@@ -28,6 +29,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     rake (13.0.6)
     rdkafka (0.12.0)
       ffi (~> 1.15)
@@ -58,11 +62,11 @@ DEPENDENCIES
   activesupport (~> 6.1.0)
   bundler (>= 1.13, < 3)
   dogstatsd-ruby (>= 4.0.0, < 6.0.0)
-  pry
+  pry-byebug
   racecar!
   rake (> 10.0)
   rspec (~> 3.0)
   timecop
 
 BUNDLED WITH
-   2.3.7
+   2.4.9

--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -66,12 +66,16 @@ module Racecar
   end
 
   def self.run(processor)
+    runner(processor).run
+  end
+
+  def self.runner(processor)
     runner = Runner.new(processor, config: config, logger: logger, instrumenter: config.instrumenter)
 
     if config.parallel_workers && config.parallel_workers > 1
-      ParallelRunner.new(runner: runner, config: config, logger: logger).run
+      ParallelRunner.new(runner: runner, config: config, logger: logger)
     else
-      runner.run
+      runner
     end
   end
 end

--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -19,6 +19,7 @@ module Racecar
       @parser = build_parser
       @parser.parse!(args)
       @consumer_name = args.first or raise Racecar::Error, "no consumer specified"
+      @runner = nil
     end
 
     def run
@@ -65,8 +66,13 @@ module Racecar
       end
 
       processor = consumer_class.new
-      Racecar.run(processor)
+      @runner = Racecar.runner(processor)
+      @runner.run
       nil
+    end
+
+    def stop
+      @runner.stop
     end
 
     private

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -6,6 +6,7 @@ require "king_konf"
 
 require "racecar/liveness_probe"
 require "racecar/instrumenter"
+require "racecar/rebalance_listener"
 
 module Racecar
   class Config < KingKonf::Config
@@ -227,6 +228,7 @@ module Racecar
     end
 
     def load_consumer_class(consumer_class)
+      self.consumer_class = consumer_class
       self.group_id = consumer_class.group_id || self.group_id
 
       self.group_id ||= [
@@ -243,6 +245,7 @@ module Racecar
       self.fetch_messages = consumer_class.fetch_messages || self.fetch_messages
       self.pidfile ||= "#{group_id}.pid"
     end
+    attr_accessor :consumer_class
 
     def on_error(&handler)
       @error_handler = handler
@@ -291,6 +294,10 @@ module Racecar
         liveness_probe_file_path,
         liveness_probe_max_interval
       )
+    end
+
+    def rebalance_listener
+      RebalanceListener.new(self)
     end
 
     private

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -69,7 +69,10 @@ module Racecar
 
     def current
       @consumers[@consumer_id_iterator.peek] ||= begin
-        consumer = Rdkafka::Config.new(rdkafka_config(current_subscription)).consumer
+        consumer_config = Rdkafka::Config.new(rdkafka_config(current_subscription))
+        consumer_config.consumer_rebalance_listener = @config.rebalance_listener
+
+        consumer = consumer_config.consumer
         @instrumenter.instrument('join_group') do
           consumer.subscribe current_subscription.topic
         end

--- a/lib/racecar/parallel_runner.rb
+++ b/lib/racecar/parallel_runner.rb
@@ -37,6 +37,10 @@ module Racecar
       wait_for_exit
     end
 
+    def stop
+      terminate_workers
+    end
+
     private
 
     attr_accessor :workers

--- a/lib/racecar/rebalance_listener.rb
+++ b/lib/racecar/rebalance_listener.rb
@@ -1,0 +1,22 @@
+module Racecar
+  class RebalanceListener
+    def initialize(config)
+      @config = config
+      @consumer_class = config.consumer_class
+    end
+
+    attr_reader :config, :consumer_class
+
+    def on_partitions_assigned(_consumer, topic_partition_list)
+      consumer_class.respond_to?(:on_partitions_assigned) &&
+        consumer_class.on_partitions_assigned(topic_partition_list.to_h)
+    rescue
+    end
+
+    def on_partitions_revoked(_consumer, topic_partition_list)
+      consumer_class.respond_to?(:on_partitions_revoked) &&
+        consumer_class.on_partitions_revoked(topic_partition_list.to_h)
+    rescue
+    end
+  end
+end

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rdkafka",   "~> 0.12.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "timecop"

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -18,11 +18,12 @@ RSpec.describe Racecar::Cli do
       expect($stderr).to receive(:puts).with(/Wro+m!/)
       expect($stderr).to receive(:puts).with(/Ctrl-C to shutdown consumer/)
     end
+    let(:mock_runner) { double(:mock_runner, run: nil) }
 
     it "doesn't start Rails if --without-rails option is specified" do
       args = ["--require", "./examples/cat_consumer.rb", "CatConsumer", "--without-rails"]
 
-      allow(Racecar).to receive(:run)
+      allow(Racecar).to receive(:runner).and_return(mock_runner)
       expect(Racecar::RailsConfigFileLoader).not_to receive(:load!)
 
       Racecar::Cli.main(args)
@@ -31,7 +32,7 @@ RSpec.describe Racecar::Cli do
     it "starts Rails if the --without-rails option is omitted" do
       args = ["--require", "./examples/cat_consumer.rb", "CatConsumer"]
 
-      allow(Racecar).to receive(:run)
+      allow(Racecar).to receive(:runner).and_return(mock_runner)
       expect(Racecar::RailsConfigFileLoader).to receive(:load!)
 
       Racecar::Cli.main(args)

--- a/spec/consumer_set_spec.rb
+++ b/spec/consumer_set_spec.rb
@@ -15,7 +15,7 @@ end
 RSpec.describe Racecar::ConsumerSet do
   let(:config)              { Racecar::Config.new }
   let(:rdconsumer)          { double("rdconsumer", subscribe: true) }
-  let(:rdconfig)            { double("rdconfig", consumer: rdconsumer) }
+  let(:rdconfig)            { double("rdconfig", consumer: rdconsumer, "consumer_rebalance_listener=": nil) }
   let(:logger)              { Logger.new(StringIO.new) }
   let(:instrumenter)        { Racecar::NullInstrumenter }
   let(:consumer_set)        { Racecar::ConsumerSet.new(config, logger, instrumenter) }

--- a/spec/integration/consumer_spec.rb
+++ b/spec/integration/consumer_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "securerandom"
 require "racecar/cli"
-require "racecar/ctl"
+require "active_support/notifications"
 
 class NoSubsConsumer < Racecar::Consumer
   def process(message); end
@@ -56,52 +55,32 @@ RSpec.describe "running a Racecar consumer", type: :integration do
   end
 
   context "when the runner starts successfully" do
+    let!(:racecar_cli) { Racecar::Cli.new([consumer_class.name.to_s]) }
     let(:input_topic) { generate_input_topic_name }
     let(:output_topic) { generate_output_topic_name }
-    let(:mock_echo_consumer_class) do
-      Class.new(Racecar::Consumer) do
-        class << self
-          attr_accessor :output_topic
-        end
-
-        def process(message)
-          produce message.value, key: message.key, topic: self.class.output_topic
-          deliver!
-        end
-      end
-    end
+    let(:group_id) { generate_group_id }
+    let(:consumer_class) { IntegrationTestConsumer = echo_consumer_class }
 
     before do
+      Racecar.config.max_wait_time = 0.1
       create_topic(topic: input_topic, partitions: topic_partitions)
       create_topic(topic: output_topic, partitions: topic_partitions)
 
       consumer_class.subscribes_to(input_topic)
       consumer_class.output_topic = output_topic
       consumer_class.parallel_workers = parallelism
-
-      publish_messages!(input_topic, input_messages)
     end
 
-    after(:all) { delete_all_test_topics }
-
     context "for a single threaded consumer" do
-      let(:consumer_class) do
-        class EchoConsumer1 < mock_echo_consumer_class
-          self.group_id = "echo-consumer-1"
-        end
-        EchoConsumer1
-      end
-
       let(:input_messages) { [{ payload: "hello", key: "greetings", partition: nil }] }
       let(:topic_partitions) { 1 }
       let(:parallelism) { nil }
 
       it "can consume and publish a message" do
-        in_background(cleanup_callback: -> { Process.kill("INT", Process.pid) }) do
-          wait_for_messages(topic: output_topic, expected_message_count: 1)
-        end
+        start_racecar
 
-        Racecar::Cli.new([consumer_class.name.to_s]).run
+        publish_messages
+        wait_for_messages
 
         message = incoming_messages.first
 
@@ -114,82 +93,86 @@ RSpec.describe "running a Racecar consumer", type: :integration do
 
     context "when running parallel workers" do
       let(:input_messages) do
-        [
-          { payload: "message-0", partition: 0, key: "a" },
-          { payload: "message-1", partition: 1, key: "a" },
-          { payload: "message-2", partition: 2, key: "a" },
-          { payload: "message-3", partition: 3, key: "a" },
-          { payload: "message-4", partition: 4, key: "a" },
-          { payload: "message-5", partition: 5, key: "a" }
-        ]
+        6.times.map { |n|
+          { payload: "message-#{n}", partition: n % topic_partitions }
+        }
       end
 
       context "when partitions exceed parallelism" do
         let(:topic_partitions) { 6 }
         let(:parallelism) { 3 }
-        let(:consumer_class) do
-          class EchoConsumer2 < mock_echo_consumer_class
-            self.group_id = "echo-consumer-2"
-          end
-          EchoConsumer2
-        end
 
         it "assigns partitions to all parallel workers" do
-          in_background(cleanup_callback: -> { Process.kill("INT", Process.pid) }) do
-            wait_for_assignments(
-              group_id: "echo-consumer-2",
-              topic: input_topic,
-              expected_members_count: parallelism
-            )
-            wait_for_messages(topic: output_topic, expected_message_count: input_messages.count)
-          end
+          start_racecar
 
-          Racecar::Cli.new([consumer_class.name.to_s]).run
+          wait_for_assignments(parallelism)
+          publish_messages
+          wait_for_messages
+
+          message_count_by_worker = incoming_messages.group_by { |m| m.headers.fetch(:processed_by_pid) }.transform_values(&:count)
 
           expect(incoming_messages.map(&:topic).uniq).to eq([output_topic])
           expect(incoming_messages.map(&:payload))
             .to match_array(input_messages.map { |m| m[:payload] })
+          expect(message_count_by_worker.values).to eq([2,2,2])
         end
       end
 
       context "when the parallelism exceeds the number of partitions" do
-        let(:consumer_class) do
-          class EchoConsumer3 < mock_echo_consumer_class
-            self.group_id = "echo-consumer-3"
-          end
-          EchoConsumer3
-        end
-
         let(:topic_partitions) { 3 }
         let(:parallelism) { 5 }
-        let(:input_messages) do
-          [
-            { payload: "message-0", partition: 0, key: "a" },
-            { payload: "message-1", partition: 0, key: "a" },
-            { payload: "message-2", partition: 1, key: "a" },
-            { payload: "message-3", partition: 1, key: "a" },
-            { payload: "message-4", partition: 2, key: "a" },
-            { payload: "message-5", partition: 2, key: "a" }
-          ]
-        end
 
         it "assigns all the consumers that it can, up to the total number of partitions" do
-          in_background(cleanup_callback: -> { Process.kill("INT", Process.pid) }) do
-            wait_for_assignments(
-              group_id: "echo-consumer-3",
-              topic: input_topic,
-              expected_members_count: topic_partitions
-            )
-            wait_for_messages(topic: output_topic, expected_message_count: input_messages.count)
-          end
+          start_racecar
 
-          Racecar::Cli.new([consumer_class.name.to_s]).run
+          wait_for_assignments(parallelism)
+          publish_messages
+          wait_for_messages
+
+          message_count_by_worker = incoming_messages.group_by { |m| m.headers.fetch(:processed_by_pid) }.transform_values(&:count)
 
           expect(incoming_messages.count).to eq(6)
           expect(incoming_messages.map(&:topic).uniq).to eq([output_topic])
           expect(incoming_messages.map(&:payload))
             .to match_array(input_messages.map { |m| m[:payload] })
+          expect(message_count_by_worker.values).to eq([2,2,2])
         end
+      end
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :IntegrationTestConsumer) if defined?(IntegrationTestConsumer)
+  end
+
+  def echo_consumer_class
+    test_instance = self
+
+    Class.new(Racecar::Consumer) do
+      class << self
+        attr_accessor :output_topic
+        attr_accessor :pipe_to_test
+      end
+      self.group_id = test_instance.group_id
+      self.pipe_to_test = test_instance.consumer_message_pipe.write_end
+
+      def self.on_partitions_assigned(topic_partition_list)
+        Racecar.logger.info("on_partitions_assigned #{topic_partition_list.to_h}")
+
+        pipe_to_test.puts(JSON.dump({group_id: self.group_id, pid: Process.pid}))
+      end
+
+      def process(message)
+        produce(message.value, key: message.key, topic: self.class.output_topic, headers: headers)
+        deliver!
+      end
+
+      private
+
+      def headers
+        {
+          processed_by_pid: Process.pid,
+        }
       end
     end
   end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -240,6 +240,9 @@ class FakeRdkafka
   def producer(*)
     FakeProducer.new(self, @runner)
   end
+
+  def consumer_rebalance_listener=(_listenr)
+  end
 end
 
 class FakeInstrumenter < Racecar::Instrumenter

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require "timecop"
+require "timeout"
+require "pry-byebug"
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "racecar"
-require "timecop"
+
 require_relative 'support/mock_env'
 require_relative 'support/integration_helper'
 Thread.abort_on_exception = true
@@ -11,4 +15,8 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.include MockEnv
   config.include IntegrationHelper, type: :integration
+
+  config.before do
+    Racecar.config = Racecar::Config.new
+  end
 end


### PR DESCRIPTION
TL;DR Integration specs 3x faster ~45s -> 15s

This is a huge itch-scratch PR that addresses _most_ of the issues I have with the integration specs. Hopefully we're in agreement and maybe it's an easy merge 🤞🤷😬 🗒️ 

Here's the full laundry list:

- Replace Kafka CLI with `librdkadfka` admin connection for creation and
  deletion of test topics.
- Racecar::CLI implements `#stop` which is now used instead of the test
  process sending `SIGINT` to itself.
- Hook into rebalance callbacks to get a fast, reliable indication of assignments for test setup, again replacing slow CLI tools.
- Use a pipe in forked consumer processes to signal assignments back to
  the test.
- Tag messages with PIDs to confirm concurrency via message state.
- Reset implicitly installed signal handlers between tests.
- Reset Racecar config between tests.
- Use a consistent test consumer class for integration tests, rebuild it
  for every test.
- Ensure _all_ child processes have shutdown, print a warning after
  timeout.
- Removed `#in_background` and callback mechanism in favor of running
  the consumer in a thread and controlling the test from the main
  thread.