### PR TITLE
Resume topic/partition in all consumers

### DIFF
--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -98,13 +98,11 @@ module Racecar
     end
 
     def resume(topic, partition)
-      consumer, filtered_tpl = find_consumer_by(topic, partition)
-      if !consumer
-        @logger.info "Attempted to resume #{topic}/#{partition}, but we're not subscribed to it"
-        return
+      each do |consumer|
+        tpl = Rdkafka::Consumer::TopicPartitionList.new
+        tpl.add_topic(topic , [partition])
+        consumer.resume(tpl)
       end
-
-      consumer.resume(filtered_tpl)
     end
 
     alias :each :each_subscribed

--- a/spec/consumer_set_spec.rb
+++ b/spec/consumer_set_spec.rb
@@ -95,11 +95,6 @@ RSpec.describe Racecar::ConsumerSet do
           end
           consumer_set.resume("greetings", 0)
         end
-
-        it "#resume doesn't resume unknown partitions" do
-          expect(rdconsumer).not_to receive(:resume)
-          consumer_set.resume("greetings", 1)
-        end
       end
 
       describe "#poll" do
@@ -382,21 +377,11 @@ RSpec.describe Racecar::ConsumerSet do
         consumer_set.pause("unknowntopic", 0, 1233456)
       end
 
-      it "#resume resumes partition in right consumer" do
+      it "#resume resumes partition in all consumers" do
+        expect(rdconsumer1).to receive(:resume).once
+        expect(rdconsumer2).to receive(:resume).once
         expect(rdconsumer3).to receive(:resume).once
         consumer_set.resume("account", 0)
-      end
-
-      it "#resume doesn't resume unknown partitions" do
-        expect(rdconsumer3).not_to receive(:resume)
-        consumer_set.resume("account", 1)
-      end
-
-      it "#resume doesn't resume unknown topics" do
-        expect(rdconsumer1).not_to receive(:resume)
-        expect(rdconsumer2).not_to receive(:resume)
-        expect(rdconsumer3).not_to receive(:resume)
-        consumer_set.resume("unknowntopic", 0)
       end
     end
 


### PR DESCRIPTION
Prior to this, when a pause expires in a partition that is no longer assigned to the client, we don't call resume on the rdkafka consumers. If this partition is then re-assigned to the consumer, we don't start consuming messages from it because it is still paused as far as the rdkafka consumer is concerned.

Since we only track `Pause`s by topic and partition, and we don't have any information about which consumer the pause exists for, our only option is to resume the topic/partition on all consumers. This won't cause errors because it's safe to call resume for a non-existent topic/partition. If there are multiple consumers with the same topic/partition (like from different Kafka clusters), this has the potential to erroneously resume partitions. In general this isn't a huge deal because if the partition fails again it will just be re-paused. Ultimately it would probably be a good idea to make pauses aware of the consumer, or add logic to remove rdkafka-level consumer pauses in rebalance callbacks.