### PR TITLE
Add observality for producer errors

### DIFF
--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -269,6 +269,10 @@ module Racecar
           topic: topic,
         }
 
+        if event.payload.key?(:exception)
+          increment("producer.produce.errors", tags: tags)
+        end
+
         # This gets us the write rate.
         increment("producer.produce.messages", tags: tags.merge(topic: topic))
 
@@ -291,6 +295,11 @@ module Racecar
           client: client,
           topic: topic,
         }
+
+        if event.payload.key?(:exception)
+          increment("producer.produce.errors", tags: tags)
+        end
+
 
         # This gets us the write rate.
         increment("producer.produce.messages", tags: tags.merge(topic: topic))

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -211,8 +211,12 @@ module Racecar
           topic: topic,
         }
 
-        # This gets us the write rate.
-        increment("producer.produce.messages", tags: tags.merge(topic: topic))
+        if event.payload.key?(:exception)
+          increment("producer.produce.errors", tags: tags)
+        else
+          # This gets us the write rate.
+          increment("producer.produce.messages", tags: tags.merge(topic: topic))
+        end
 
         # Information about typical/average/95p message size.
         histogram("producer.produce.message_size", message_size, tags: tags.merge(topic: topic))

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -249,12 +249,12 @@ module Racecar
         increment("producer.ack.messages", tags: tags)
       end
 
-      def produce_error(event)
+      def produce_delivery_error(event)
         tags = {
           client: event.payload.fetch(:client_id),
         }
 
-        increment("producer.produce.errors", tags: tags)
+        increment("producer.produce.delivery.errors", tags: tags)
       end
 
       def produce_async(event)

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -252,7 +252,6 @@ module Racecar
       def produce_error(event)
         tags = {
           client: event.payload.fetch(:client_id),
-          topic: event.payload.fetch(:topic),
         }
 
         increment("producer.produce.errors", tags: tags)

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -213,10 +213,10 @@ module Racecar
 
         if event.payload.key?(:exception)
           increment("producer.produce.errors", tags: tags)
-        else
-          # This gets us the write rate.
-          increment("producer.produce.messages", tags: tags.merge(topic: topic))
         end
+
+        # This gets us the write rate.
+        increment("producer.produce.messages", tags: tags.merge(topic: topic))
 
         # Information about typical/average/95p message size.
         histogram("producer.produce.message_size", message_size, tags: tags.merge(topic: topic))

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -248,7 +248,16 @@ module Racecar
         # Number of messages ACK'd for the topic.
         increment("producer.ack.messages", tags: tags)
       end
-      
+
+      def produce_error(event)
+        tags = {
+          client: event.payload.fetch(:client_id),
+          topic: event.payload.fetch(:topic),
+        }
+
+        increment("producer.produce.errors", tags: tags)
+      end
+
       def produce_async(event)
         client = event.payload.fetch(:client_id)
         topic = event.payload.fetch(:topic)

--- a/lib/racecar/delivery_callback.rb
+++ b/lib/racecar/delivery_callback.rb
@@ -14,12 +14,11 @@ module Racecar
         }
         @instrumenter.instrument("acknowledged_message", payload)
       else
-        instrumentation_payload = {
-          topic: delivery_report.topic_name,
+        payload = {
           partition: delivery_report.partition,
           exception: delivery_report.error
         }
-        @instrumenter.instrument("produce_error", instrumentation_payload)
+        @instrumenter.instrument("produce_error", payload)
       end
     end
   end

--- a/lib/racecar/delivery_callback.rb
+++ b/lib/racecar/delivery_callback.rb
@@ -7,19 +7,19 @@ module Racecar
     end
 
     def call(delivery_report)
-      if delivery_report.error.to_i.positive?
+      if delivery_report.error.to_i.zero?
+        payload = {
+          offset: delivery_report.offset,
+          partition: delivery_report.partition
+        }
+        @instrumenter.instrument("acknowledged_message", payload)
+      else
         instrumentation_payload = {
           topic: delivery_report.topic_name,
           partition: delivery_report.partition,
           exception: delivery_report.error
         }
         @instrumenter.instrument("produce_error", instrumentation_payload)
-      else
-        payload = {
-          offset: delivery_report.offset,
-          partition: delivery_report.partition
-        }
-        @instrumenter.instrument("acknowledged_message", payload)
       end
     end
   end

--- a/lib/racecar/delivery_callback.rb
+++ b/lib/racecar/delivery_callback.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Racecar
   class DeliveryCallback
     attr_reader :instrumenter
@@ -12,13 +14,13 @@ module Racecar
           offset: delivery_report.offset,
           partition: delivery_report.partition
         }
-        @instrumenter.instrument("acknowledged_message", payload)
+        instrumenter.instrument("acknowledged_message", payload)
       else
         payload = {
           partition: delivery_report.partition,
           exception: delivery_report.error
         }
-        @instrumenter.instrument("produce_error", payload)
+        instrumenter.instrument("produce_delivery_error", payload)
       end
     end
   end

--- a/lib/racecar/delivery_callback.rb
+++ b/lib/racecar/delivery_callback.rb
@@ -1,0 +1,26 @@
+module Racecar
+  class DeliveryCallback
+    attr_reader :instrumenter
+
+    def initialize(instrumenter:)
+      @instrumenter = instrumenter
+    end
+
+    def call(delivery_report)
+      if delivery_report.error.to_i.positive?
+        instrumentation_payload = {
+          topic: delivery_report.topic_name,
+          partition: delivery_report.partition,
+          exception: delivery_report.error
+        }
+        @instrumenter.instrument("produce_error", instrumentation_payload)
+      else
+        payload = {
+          offset: delivery_report.offset,
+          partition: delivery_report.partition
+        }
+        @instrumenter.instrument("acknowledged_message", payload)
+      end
+    end
+  end
+end

--- a/lib/racecar/producer.rb
+++ b/lib/racecar/producer.rb
@@ -43,20 +43,24 @@ module Racecar
           }
           producer_config["compression.codec"] = config.producer_compression_codec.to_s unless config.producer_compression_codec.nil?
           producer_config.merge!(config.rdkafka_producer)
-          producer = Rdkafka::Config.new(producer_config).producer.tap do |producer|
+          Rdkafka::Config.new(producer_config).producer.tap do |producer|
             producer.delivery_callback = DeliveryCallback.new(instrumenter: @instrumenter)
           end
         end
       end
     end
 
-    # fire and forget - you won't get any guarantees or feedback from 
+    # fire and forget - you won't get any guarantees or feedback from
     # Racecar on the status of the message and it won't halt execution
     # of the rest of your code.
     def produce_async(value:, topic:, **options)
       with_instrumentation(action: "produce_async", value: value, topic: topic, **options) do
-        handle = internal_producer.produce(payload: value, topic: topic, **options)
-        @delivery_handles << handle if @batching
+        begin
+          handle = internal_producer.produce(payload: value, topic: topic, **options)
+          @delivery_handles << handle if @batching
+        rescue Rdkafka::RdkafkaError => e
+          raise MessageDeliveryError.new(e, handle)
+        end
       end
 
       nil

--- a/lib/racecar/producer.rb
+++ b/lib/racecar/producer.rb
@@ -64,9 +64,24 @@ module Racecar
 
     # synchronous message production - will wait until the delivery handle succeeds, fails or times out.
     def produce_sync(value:, topic:, **options)
-      with_instrumentation(action: "produce_sync", value: value, topic: topic, **options) do
+      message_size = value.respond_to?(:bytesize) ? value.bytesize : 0
+      instrumentation_payload = {
+        value: value,
+        topic: topic,
+        message_size: message_size,
+        buffer_size: @delivery_handles.size,
+        key: options.fetch(:key, nil),
+        partition: options.fetch(:partition, nil),
+        partition_key: options.fetch(:partition_key, nil)
+      }
+      @instrumenter.instrument("produce_sync", instrumentation_payload) do
         handle = internal_producer.produce(payload: value, topic: topic, **options)
-        deliver_with_error_handling(handle)
+        begin
+          deliver_with_error_handling(handle)
+        rescue MessageDeliveryError => e
+          instrumentation_payload[:exception] = e
+          raise e
+        end
       end
 
       nil

--- a/lib/racecar/producer.rb
+++ b/lib/racecar/producer.rb
@@ -65,8 +65,12 @@ module Racecar
     # synchronous message production - will wait until the delivery handle succeeds, fails or times out.
     def produce_sync(value:, topic:, **options)
       with_instrumentation(action: "produce_sync", value: value, topic: topic, **options) do
-        handle = internal_producer.produce(payload: value, topic: topic, **options)
-        deliver_with_error_handling(handle)
+        begin
+          handle = internal_producer.produce(payload: value, topic: topic, **options)
+          deliver_with_error_handling(handle)
+        rescue Rdkafka::RdkafkaError => e
+          raise MessageDeliveryError.new(e, handle)
+        end
       end
 
       nil

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -181,6 +181,8 @@ class FakeProducer
   end
 end
 
+FakeDeliveryReport = Struct.new(:partition, :offset, :error, :topic_name)
+
 class FakeDeliveryHandle
   def initialize(kafka, msg, delivery_callback)
     @kafka = kafka
@@ -192,9 +194,13 @@ class FakeDeliveryHandle
     @msg.public_send(key)
   end
 
+  def report
+    FakeDeliveryReport.new(0, 0, 0, "test")
+  end
+
   def wait(max_wait_timeout: 60, wait_timeout: 0.1)
     @kafka.produced_messages << @msg
-    @delivery_callback.call(self) if @delivery_callback
+    @delivery_callback.call(report) if @delivery_callback
   end
 
   def create_result
@@ -680,6 +686,7 @@ RSpec.describe Racecar::Runner do
     end
 
     it "instruments delivery notifications" do
+      allow_any_instance_of(FakeDeliveryReport).to receive(:error).and_return(0)
       allow(instrumenter).to receive(:instrument).and_call_original
       kafka.deliver_message("2", topic: "numbers")
 


### PR DESCRIPTION
Currently, we lack observability to detect errors when using the Standalone Producer. This pull request introduces improvements to error handling and instrumentation in standalone producer. The primary goal is to enhance visibility into producer errors. It's using delivery callback to instrument events for both successful and failed deliveries.

Here are stats and exceptions in various scenarios

```ruby
  # partition 99 does not exist and is used to trigger error
  # huge msg payload is used to trigger another error
  huge = "HUGE" * 10000

  # Sync: success
  # expected stats
  # [StatsD] racecar.producer.ack.messages 1|c| client:racecar
  # [StatsD] racecar.producer.produce.messages 1|c| client:racecar topic:messages
  #
  # No exceeption raised
  Racecar.produce_sync(value: "test message #{Time.now}", topic: "messages")

  # Sync: failure, invalid partition
  # expected stats
  # [StatsD] racecar.producer.produce.delivery.errors 1|c| client:racecar
  # [StatsD] racecar.producer.produce.errors 1|c| client:racecar topic:messages
  # [StatsD] racecar.producer.produce.messages 1|c| client:racecar topic:messages
  #
  # Following exception is raised
  # #<Racecar::MessageDeliveryError: Message delivery finally failed:
  # Local: Unknown partition (unknown_partition)
  #
  Racecar.produce_sync(value: "test message #{Time.now}", topic: "messages", partition: 99)

  # Sync: failure, huge message
  # expected stats
  # [StatsD] racecar.producer.produce.errors 1|c| client:racecar topic:messages
  # [StatsD] racecar.producer.produce.messages 1|c| client:racecar topic:messages
  #
  # Following exception is raised
  # #<Racecar::MessageDeliveryError: Message delivery finally failed:
  # Broker: Message size too large (msg_size_too_large)
  #
  Racecar.produce_sync(value: "test message #{huge} #{Time.now}", topic: "messages")

  # Async: failure, huge message
  # expected stats
  # [StatsD] racecar.producer.produce.errors 1|c| client:racecar topic:messages
  # [StatsD] racecar.producer.produce.messages 1|c| client:racecar topic:messages
  #
  # Following exception is raised
  # #<Racecar::MessageDeliveryError: Message delivery finally failed:
  # Broker: Message size too large (msg_size_too_large)
  #
  Racecar.produce_async(value: "test message #{huge} #{Time.now}", topic: "messages")

  # Async: failure, invalid partition
  # expected stats
  # [StatsD] racecar.producer.produce.messages 1|c| client:racecar topic:messages
  # [StatsD] racecar.producer.produce.delivery.errors 1|c| client:racecar
  #
  # No Exception raised
  #
  Racecar.produce_async(value: "test message #{Time.now}", topic: "messages", partition: 99)

  # Async: success
  # expected stats
  # [StatsD] racecar.producer.produce.messages 1|c| client:racecar topic:messages
  # [StatsD] racecar.producer.ack.messages 1|c| client:racecar
  #
  # This should not raise any exception
  Racecar.produce_async(value: "test message #{Time.now}", topic: "messages")
```

NOTE: In some cases there error is instrumented twice, once via delivery callback and once via exception handling, for example using sync producer with invalid partition. This happens with sync because handle.wait raises an error, and delivery callback also reports the error.