### PR TITLE
Update test docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.7.2
+FROM cimg/ruby:2.7.8
 
 RUN sudo apt-get update
 RUN sudo apt-get install docker

--- a/README.md
+++ b/README.md
@@ -681,12 +681,12 @@ The integration tests run against a Kafka instance that is not automatically sta
 
 ### Running RSpec within Docker
 
-There can be behavioural inconsistencies between running the specs on your machine, and in the CI pipeline. Due to this, there is now a Dockerfile included in the project, which is based on the CircleCI ruby 2.7.2 image. This could easily be extended with more Dockerfiles to cover different Ruby versions if desired. In order to run the specs via Docker:
+There can be behavioural inconsistencies between running the specs on your machine, and in the CI pipeline. Due to this, there is now a Dockerfile included in the project, which is based on the CircleCI ruby 2.7.8 image. This could easily be extended with more Dockerfiles to cover different Ruby versions if desired. In order to run the specs via Docker:
 
 - Uncomment the `tests` service from the docker-compose.yml
 - Bring up the stack with `docker-compose up -d`
-- Execute the entire suite with `docker-compose run --rm tests rspec`
-- Execute a single spec or directory with `docker-compose run --rm tests rspec spec/integration/consumer_spec.rb`
+- Execute the entire suite with `docker-compose run --rm tests bundle exec rspec`
+- Execute a single spec or directory with `docker-compose run --rm tests bundle exec rspec spec/integration/consumer_spec.rb`
 
 Please note - your code directory is mounted as a volume, so you can make code changes without needing to rebuild
 

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -95,7 +95,7 @@ module Racecar
       end
     ensure
       producer.close
-      Racecar::Datadog.close if Object.const_defined?("Racecar::Datadog")
+      Racecar::Datadog.close if config.datadog_enabled
       @instrumenter.instrument("shut_down", instrumentation_payload || {})
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe Racecar::Config do
 
   describe "#load_env" do
     it "sets the brokers from RACECAR_BROKERS" do
-      ENV["RACECAR_BROKERS"] = "hansel,gretel"
-
-      expect(config.brokers).to eq ["hansel", "gretel"]
+      with_env("RACECAR_BROKERS", "hansel,gretel") do
+        expect(config.brokers).to eq ["hansel", "gretel"]
+      end
     end
 
     it "sets the client id from RACECAR_CLIENT_ID" do
@@ -92,15 +92,15 @@ RSpec.describe Racecar::Config do
     end
 
     it "sets the offset commit interval from RACECAR_OFFSET_COMMIT_INTERVAL" do
-      ENV["RACECAR_OFFSET_COMMIT_INTERVAL"] = "45"
-
-      expect(config.offset_commit_interval).to eq 45
+      with_env("RACECAR_OFFSET_COMMIT_INTERVAL", '45') do
+        expect(config.offset_commit_interval).to eq 45
+      end
     end
 
     it "sets the heartbeat interval from RACECAR_HEARTBEAT_INTERVAL" do
-      ENV["RACECAR_HEARTBEAT_INTERVAL"] = "45"
-
-      expect(config.heartbeat_interval).to eq 45
+      with_env("RACECAR_HEARTBEAT_INTERVAL", "45") do
+        expect(config.heartbeat_interval).to eq 45
+      end
     end
   end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -711,7 +711,8 @@ RSpec.describe Racecar::Runner do
 
     context "when DataDog metrics are disabled" do
       before do
-        allow(Object).to receive(:const_defined?).with("Racecar::Datadog").and_return(false)
+        stub_const("Racecar::Datadog", datadog)
+        config.datadog_enabled = false
       end
 
       it "does not close Datadog::Statsd instance" do
@@ -723,7 +724,7 @@ RSpec.describe Racecar::Runner do
     context "when DataDog metrics are enabled" do
       before do
         stub_const("Racecar::Datadog", datadog)
-        allow(Object).to receive(:const_defined?).with("Racecar::Datadog").and_return(true)
+        config.datadog_enabled = true
       end
 
       it "closes Datadog::Statsd instance" do


### PR DESCRIPTION
* Updates circle ci ruby image [from the legacy image](https://circleci.com/developer/images/image/cimg/ruby)
* Allows the entire test suite (unit and integration) to be run together by fixing some side effects from other specs
* Use `config.datadog_enabled` for datadog related commands instead of `Object.const_defined?("Racecar::Datadog")`