### PR TITLE
Send exceptions to `process_batch` instrumenter

### DIFF
--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -87,6 +87,15 @@ RSpec.describe Racecar::Datadog::ConsumerSubscriber do
 
       subscriber.process_message(event)
     end
+
+    it 'publishes errors' do
+      event.payload[:exception] = StandardError.new("surprise")
+      expect(statsd).
+        to receive(:increment).
+        with("consumer.process_message.errors", tags: metric_tags)
+
+      subscriber.process_message(event)
+    end
   end
 
   describe '#process_batch' do
@@ -134,6 +143,15 @@ RSpec.describe Racecar::Datadog::ConsumerSubscriber do
       expect(statsd).
         to receive(:gauge).
         with('consumer.offset', 10, tags: metric_tags)
+
+      subscriber.process_batch(event)
+    end
+
+    it 'publishes errors' do
+      event.payload[:exception] = StandardError.new("surprise")
+      expect(statsd).
+        to receive(:increment).
+        with("consumer.process_batch.errors", tags: metric_tags)
 
       subscriber.process_batch(event)
     end


### PR DESCRIPTION
When exceptions are raised by the processing code in `process_batch`, the `with_pause` method is swallowing them, so the instrumentation does not receive the exception

This PR makes it so that the instrumentation receives the processing exceptions.
