### PR TITLE
Run tests on Ruby 3.3 (preview 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3.0-preview2"
 
     steps:
     - uses: zendesk/checkout@v3


### PR DESCRIPTION
Runs tests on [Ruby 3.3 (preview 2)](https://www.ruby-lang.org/en/news/2023/09/14/ruby-3-3-0-preview2-released/) to catch possible common issues before the final release. 
