### PR TITLE
Configurable strategy for consuming multiple topics

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -185,6 +185,9 @@ module Racecar
     desc "Used only by the liveness probe: Max time (in seconds) between liveness events before the process is considered not healthy"
     integer :liveness_probe_max_interval, default: 5
 
+    desc "Strategy for switching topics when there are multiple subscriptions. `exhaust-topic` will only switch when the consumer poll returns no messages. `round-robin` will switch after each poll regardless.\nWarning: `round-robin` will be the default in Racecar 3.x"
+    string :multi_subscription_strategy, allowed_values: %w(round-robin exhaust-topic), default: "exhaust-topic"
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 


### PR DESCRIPTION
The current ConsumerSet implementation will only switch topics when the current topic returns no messages after the poll timeout.

This is not practical when one or more of the topics has a 'high' message volume as the broker will always return a message and Racecar may never switch to poll the other topics.

* 'high' here means message frequency (hz) > poll interval (s).