### PR TITLE
Upgrade `rdkafka` ~> 0.15; require Ruby 3.0 since 2.6 is EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"
@@ -36,7 +35,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.0"
         bundler-cache: true
     - name: Bring up docker-compose stack
       run: docker-compose up -d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Bump minimum rdkafka gem version to 0.15.0
+* Bump minimum Ruby version to 3.0
+
 ## 2.11.0.beta1
 
 * Configurable strategy for consuming multiple topics

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.11.0.beta1)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.13.0)
+      rdkafka (~> 0.15.0)
 
 GEM
   remote: https://rubygems.org/
@@ -19,12 +19,12 @@ GEM
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     dogstatsd-ruby (5.5.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     king_konf (1.0.1)
     method_source (1.0.0)
-    mini_portile2 (2.8.1)
+    mini_portile2 (2.8.5)
     minitest (5.18.0)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -33,7 +33,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     rake (13.0.6)
-    rdkafka (0.13.0)
+    rdkafka (0.15.1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.13.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.15.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
# What
This PR completes a couple of housekeeping items:

1. Set required Ruby to >= 3.0 in the Gemspec (2.6 is EOL, 2.7 support dropping in `rdkafka-ruby` soon, too)
2. Upgrade `rdkafka` to `~> 0.15.0`

I noticed that `rdkafka` 0.15.0 minimum Ruby is 2.7 anyway.