### PR TITLE
Avoid loading config files when executing the liveness probe check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Allow the liveness probe command to skip loading config files
+
 ## 2.11.0.beta3
 
 * Fix bug with domain socket support

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -188,6 +188,9 @@ module Racecar
     desc "Used only by the liveness probe: Max time (in seconds) between liveness events before the process is considered not healthy"
     integer :liveness_probe_max_interval, default: 5
 
+    desc "Allows the liveness probe command to skip loading config files. When enabled, configure liveness probe values via environmental variables. Defaults still apply. Only applies to the liveness probe command."
+    boolean :liveness_probe_skip_config_files, default: false
+
     desc "Strategy for switching topics when there are multiple subscriptions. `exhaust-topic` will only switch when the consumer poll returns no messages. `round-robin` will switch after each poll regardless.\nWarning: `round-robin` will be the default in Racecar 3.x"
     string :multi_subscription_strategy, allowed_values: %w(round-robin exhaust-topic), default: "exhaust-topic"
 

--- a/lib/racecar/ctl.rb
+++ b/lib/racecar/ctl.rb
@@ -36,12 +36,14 @@ module Racecar
       require "racecar/liveness_probe"
       parse_options!(args)
 
-      if ENV["RAILS_ENV"] && File.exist?("config/racecar.yml")
-        Racecar.config.load_file("config/racecar.yml", ENV["RAILS_ENV"])
-      end
+      unless config.liveness_probe_skip_config_files
+        if File.exist?("config/racecar.rb")
+          require "./config/racecar"
+        end
 
-      if File.exist?("config/racecar.rb")
-        require "./config/racecar"
+        if ENV["RAILS_ENV"] && File.exist?("config/racecar.yml")
+          Racecar.config.load_file("config/racecar.yml", ENV["RAILS_ENV"])
+        end
       end
 
       Racecar.config.liveness_probe.check_liveness_within_interval!


### PR DESCRIPTION
## Proposed change

Add a new configuration option that prevents the liveness probe command from loading config files.

## Why?

It's possible, even common to end up Rails specific logic Racecar config files.

`Racecar.config.logger = Rails.logger` for example.

In these cases it's not desirable for the liveness probe to use the same configuration mechanism. A new option,`RACECAR_LIVENESS_PROBE_SKIP_CONFIG_FILES` ensures this doesn't happen.