### PR TITLE
Fix datadog unix socket path

### DIFF
--- a/lib/racecar/cli.rb
+++ b/lib/racecar/cli.rb
@@ -159,7 +159,7 @@ module Racecar
       Datadog.configure do |datadog|
         datadog.host        = config.datadog_host unless config.datadog_host.nil?
         datadog.port        = config.datadog_port unless config.datadog_port.nil?
-        datadog.socket_path = config.socket_path unless config.socket_path.nil?
+        datadog.socket_path = config.datadog_socket_path unless config.datadog_socket_path.nil?
         datadog.namespace   = config.datadog_namespace unless config.datadog_namespace.nil?
         datadog.tags        = config.datadog_tags unless config.datadog_tags.nil?
       end

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -159,7 +159,7 @@ module Racecar
     integer :datadog_port
 
     desc "The unix domain socket of the Datadog agent (when set takes precedence over host/port)"
-    integer :datadog_socket_path
+    string :datadog_socket_path
 
     desc "The namespace to use for Datadog metrics"
     string :datadog_namespace


### PR DESCRIPTION
## What

The latest beta release broke the consumer due to exception:
`NoMethodError:  undefined method 'socket_path'`

This PR should fix this