### PR TITLE
chore: bump rdkafka to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.11.0.beta4)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.15.0)
+      rdkafka (~> 0.16.0)
 
 GEM
   remote: https://rubygems.org/
@@ -33,7 +33,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     rake (13.0.6)
-    rdkafka (0.15.1)
+    rdkafka (0.16.0)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.11.0.beta4)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.16.0)
+      rdkafka (~> 0.16.1)
 
 GEM
   remote: https://rubygems.org/
@@ -33,7 +33,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     rake (13.0.6)
-    rdkafka (0.16.0)
+    rdkafka (0.16.1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.16.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.16.1"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry-byebug"

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.15.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.16.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
https://github.com/karafka/rdkafka-ruby/releases/tag/v0.16.0 was released last week. This includes support for `oauthbearer` in `KIP-768`.

NOTE: Additional changes will be required to support this type of connection which can be done in a follow up PR.