### PR TITLE
Add topic and partition to acknowledged_message event

### DIFF
--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -256,7 +256,11 @@ module Racecar
       end
 
       def acknowledged_message(event)
-        tags = { client: event.payload.fetch(:client_id) }
+        tags = {
+          client: event.payload.fetch(:client_id),
+          topic: event.payload.fetch(:topic),
+          partition: event.payload.fetch(:partition)
+        }
 
         # Number of messages ACK'd for the topic.
         increment("producer.ack.messages", tags: tags)

--- a/lib/racecar/delivery_callback.rb
+++ b/lib/racecar/delivery_callback.rb
@@ -12,13 +12,15 @@ module Racecar
       if delivery_report.error.to_i.zero?
         payload = {
           offset: delivery_report.offset,
-          partition: delivery_report.partition
+          partition: delivery_report.partition,
+          topic: delivery_report.topic_name
         }
         instrumenter.instrument("acknowledged_message", payload)
       else
         payload = {
           partition: delivery_report.partition,
-          exception: delivery_report.error
+          exception: delivery_report.error,
+          topic: delivery_report.topic_name
         }
         instrumenter.instrument("produce_delivery_error", payload)
       end

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -427,14 +427,18 @@ RSpec.describe Racecar::Datadog::ProducerSubscriber do
   describe '#acknowledged_message' do
     let(:event) do
       create_event(
-        'deliver_messages',
+        'acknowledged_message',
         client_id: 'racecar',
-        delivered_message_count: 10
+        offset: 123,
+        partition: 1,
+        topic: 'test_topic'
       )
     end
     let(:metric_tags) do
       %w[
           client:racecar
+          topic:test_topic
+          partition:1
         ]
     end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -204,7 +204,7 @@ class FakeDeliveryHandle
   end
 
   def create_result
-    Rdkafka::Producer::DeliveryReport.new(partition, offset)
+    Rdkafka::Producer::DeliveryReport.new(partition, offset, topic)
   end
 
   def offset
@@ -213,6 +213,10 @@ class FakeDeliveryHandle
 
   def partition
     0
+  end
+
+  def topic
+    "test"
   end
 end
 
@@ -719,7 +723,7 @@ RSpec.describe Racecar::Runner do
       runner.run
 
       expect(instrumenter).to have_received(:instrument)
-        .with("acknowledged_message", {partition: 0, offset: 0})
+        .with("acknowledged_message", {partition: 0, offset: 0, topic: "test"})
     end
   end
 


### PR DESCRIPTION
The standalone producer includes the topic and partition in the [instrumentation payload](https://github.com/zendesk/racecar/blob/e62b329a69a9274758713e2aa26f55809ed821b5/lib/racecar/producer.rb#L124-L138) for `produce_async` events. However, when the broker acknowledges message delivery, the payload for the `acknowledged_message` event only contains the partition and offset, but not the topic. This is of limited utility, since multiple topics are likely to have the same partition numbers. 

The rdkafka delivery report passed into the callback already includes the [topic_name](https://github.com/karafka/rdkafka-ruby/blob/90fd6001e26b45fd00d94335529f0a57ecce9f3f/lib/rdkafka/producer/delivery_report.rb#L15-L19), so I added that information to the event payload. I also updated `Racecar::Datadog::ProducerSubscriber` to add tags for the topic and partition to the `producer.ack.messages` metric reported to StatsD.