### PR TITLE
run specs in random order

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --require spec_helper
 --color
+--order random

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -4,6 +4,12 @@ require "racecar/datadog"
 
 RSpec.describe Racecar::Datadog do
   describe '.statsd' do
+    before do
+      Racecar::Datadog.socket_path = nil
+      Racecar::Datadog.host = nil
+      Racecar::Datadog.port = nil
+    end
+
     it 'configures with host/port by default' do
       statsd = Racecar::Datadog.statsd
       expect(statsd.host).to eq('127.0.0.1')


### PR DESCRIPTION
Enables random order in RSpec, fixes Datadog-related specs (we need to reset Datadog configuration before each of them).