### PR TITLE
Add tests with Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
@@ -37,7 +36,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.0"
+        ruby-version: "3.1"
         bundler-cache: true
     - name: Bring up docker-compose stack
       run: docker compose up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,20 @@ jobs:
 
   integration-specs:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "3.4"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.1"
+        ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
     - name: Bring up docker-compose stack
       run: docker compose up -d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add tests against Ruby 3.4
+* Drop support for Ruby 3.0
 
 ## 2.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add tests against Ruby 3.4
+
 ## 2.11.0
 
 * Allow the liveness probe command to skip loading config files

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in racecar.gemspec
 gemspec
 
-# We actually support version 7.x (see gemspec); this extra restriction is added just for running the test suite also
-# on Ruby 2.6, which activesupport 7.0 does not support.
-gem 'activesupport', '~> 6.1.0'
+gem 'activesupport', '~> 7.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,24 +8,36 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.3)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.2.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.2.0)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
     dogstatsd-ruby (5.5.0)
+    drb (2.2.1)
     ffi (1.16.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     king_konf (1.0.1)
+    logger (1.6.4)
     method_source (1.0.0)
     mini_portile2 (2.8.5)
-    minitest (5.18.0)
+    minitest (5.25.4)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -50,16 +62,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
+    securerandom (0.4.1)
     timecop (0.9.6)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 6.1.0)
+  activesupport (~> 7.2.0)
   bundler (>= 1.13, < 3)
   dogstatsd-ruby (>= 4.0.0, < 6.0.0)
   pry-byebug
@@ -69,4 +81,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.4.9
+   2.6.2

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
   spec.add_runtime_dependency "rdkafka",   "~> 0.15.0"

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "securerandom"
+require "active_support/isolated_execution_state"
 
 module IntegrationHelper
   def self.included(klass)


### PR DESCRIPTION
Adds tests with Ruby 3.4. I’ve also updated the version of Active Support that we use in tests and added the same Ruby versions matrix for integration tests (they take only about a minute).