### PR TITLE
Allow rdkafka versions newer than 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add tests against Ruby 3.4
 * Drop support for Ruby 3.0
+* Allow rdkafka gem versions newer than 0.15.0
 
 ## 2.11.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.11.0)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.15.0)
+      rdkafka (>= 0.15.0)
 
 GEM
   remote: https://rubygems.org/
@@ -45,7 +45,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     rake (13.0.6)
-    rdkafka (0.15.1)
+    rdkafka (0.18.0)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -68,10 +68,10 @@ module Racecar
         @instrumenter.instrument('deliver_messages', instrumentation_payload) do
           @delivery_handles.each do |handle|
             begin
-              # rdkafka-ruby checks every wait_timeout seconds if the message was
-              # successfully delivered, up to max_wait_timeout seconds before raising
-              # Rdkafka::AbstractHandle::WaitTimeoutError. librdkafka will (re)try to
-              # deliver all messages in the background, until "config.message_timeout"
+              # rdkafka-ruby checks with exponential backoff starting at 0 seconds wait
+              # if the message was successfully delivered, up to max_wait_timeout seconds
+              # before raising Rdkafka::AbstractHandle::WaitTimeoutError. librdkafka will 
+              # (re)try to deliver all messages in the background, until "config.message_timeout"
               # (message.timeout.ms) is exceeded. Phrased differently, rdkafka-ruby's
               # WaitTimeoutError is just informative.
               # The raising can be avoided if max_wait_timeout below is greater than

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -77,7 +77,7 @@ module Racecar
               # The raising can be avoided if max_wait_timeout below is greater than
               # config.message_timeout, but config is not available here (without
               # changing the interface).
-              handle.wait(max_wait_timeout: 60, wait_timeout: 0.1)
+              handle.wait(max_wait_timeout: 60)
             rescue Rdkafka::AbstractHandle::WaitTimeoutError => e
               partition = MessageDeliveryError.partition_from_delivery_handle(handle)
               # ideally we could use the logger passed to the Runner, but it is not

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.15.0"
+  spec.add_runtime_dependency "rdkafka",   ">= 0.15.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry-byebug"

--- a/spec/integration/cooperative_sticky_assignment_spec.rb
+++ b/spec/integration/cooperative_sticky_assignment_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "cooperative-sticky assignment", type: :integration do
       { payload: "message-#{n}", partition: n % topic_partitions }
     }
   end
-  let(:message_count) { 20 }
+  let(:message_count) { 250 }
 
   context "during a rebalance" do
     let!(:consumers) { [] }

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -198,7 +198,7 @@ class FakeDeliveryHandle
     FakeDeliveryReport.new(0, 0, 0, "test")
   end
 
-  def wait(max_wait_timeout: 60, wait_timeout: 0.1)
+  def wait(max_wait_timeout: 60)
     @kafka.produced_messages << @msg
     @delivery_callback.call(report) if @delivery_callback
   end


### PR DESCRIPTION
# What

This PR completes a housekeeping item:
* Allow rdkafka versions newer than 0.15.0