### PR TITLE
update zookeeper and kafka images in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '2.1'
-
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.1
+    image: confluentinc/cp-zookeeper:7.8.1
     ports:
       - "2181:2181"
     environment:
@@ -13,7 +11,7 @@ services:
       test: echo ruok | nc 127.0.0.1 2181 | grep imok
 
   broker:
-    image: confluentinc/cp-kafka:5.5.1
+    image: confluentinc/cp-kafka:7.8.1
     depends_on:
       - zookeeper
     ports:


### PR DESCRIPTION
5.5.1 is the version from the first commit for docker-compose.yml: https://github.com/zendesk/racecar/commit/d2b97e3e281a022751bda133f8eff7cc79c0bec5

This was five years ago, and we can use newer versions of these images. Unlike 5.5.1, these images are multi-arch, so you can now run `docker compose` on ARM processors.