### PR TITLE
use 200 messages in cooperative-sticky assignment spec

### DIFF
--- a/spec/integration/cooperative_sticky_assignment_spec.rb
+++ b/spec/integration/cooperative_sticky_assignment_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "cooperative-sticky assignment", type: :integration do
       { payload: "message-#{n}", partition: n % topic_partitions }
     }
   end
-  let(:message_count) { 20 }
+  let(:message_count) { 200 }
 
   context "during a rebalance" do
     let!(:consumers) { [] }


### PR DESCRIPTION
On newer rdkafka versions, tested consumers go through 20 messages before  we get to shutting down one of them (after waiting for 5 messages in a separate consumers). Increasing the number of messages ensures that we enough of them left for shutdown to generate revocations.