### PR TITLE
Add thread-based message processing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,4 +81,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.6.2
+   2.4.19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,4 +81,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.4.19
+   2.6.2

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -240,6 +240,10 @@ module Racecar
       if max_pause_timeout && !pause_with_exponential_backoff?
         raise ConfigError, "`max_pause_timeout` only makes sense when `pause_with_exponential_backoff` is enabled"
       end
+
+      if shutdown_timeout <= 1
+        raise ConfigError, "`shutdown_timeout` must be greater than 0"
+      end
     end
 
     def load_consumer_class(consumer_class)

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -194,6 +194,9 @@ module Racecar
     desc "Strategy for switching topics when there are multiple subscriptions. `exhaust-topic` will only switch when the consumer poll returns no messages. `round-robin` will switch after each poll regardless.\nWarning: `round-robin` will be the default in Racecar 3.x"
     string :multi_subscription_strategy, allowed_values: %w(round-robin exhaust-topic), default: "exhaust-topic"
 
+    desc "Number of seconds waiting for a consumer thread pool to shutdown gracefully before killing threads. Default is 60 seconds."
+    integer :shutdown_timeout, default: 60
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -10,7 +10,7 @@ module Racecar
     class << self
       attr_accessor :max_wait_time
       attr_accessor :group_id
-      attr_accessor :producer, :consumer, :parallel_workers, :fetch_messages
+      attr_accessor :producer, :consumer, :parallel_workers, :parallel_batches_executors, :fetch_messages
 
       def subscriptions
         @subscriptions ||= []
@@ -126,10 +126,6 @@ module Racecar
       end
     end
 
-    def heartbeat
-      warn "DEPRECATION WARNING: Manual heartbeats are not supported and not needed with librdkafka."
-    end
-
     # Thread-safe helper method that executes a block with exclusive access.
     # Useful for protecting critical sections when using parallel message processing.
     #
@@ -179,6 +175,10 @@ module Racecar
       @key_based_mutexes ||= Concurrent::Map.new do |map, key|
         map[key] = Mutex.new
       end
+    end
+
+    def heartbeat
+      warn "DEPRECATION WARNING: Manual heartbeats are not supported and not needed with librdkafka."
     end
   end
 end

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -7,6 +7,12 @@ module Racecar
   class Consumer
     Subscription = Struct.new(:topic, :start_from_beginning, :max_bytes_per_partition, :additional_config)
 
+    attr_writer :parallel_batches_executors
+
+    def parallel_batches_executors
+      @parallel_batches_executors || self.class.parallel_batches_executors
+    end
+
     class << self
       attr_accessor :max_wait_time
       attr_accessor :group_id

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -49,7 +49,7 @@ module Racecar
     end
 
     def setup_multithreading
-      if processor.respond_to?(:parallel_batches_executors) && processor.parallel_batches_executors > 0
+      if !processor.parallel_batches_executors.nil? && processor.parallel_batches_executors > 0
         logger.info "Running with parallel batch processing with #{processor.parallel_batches_executors} threads"
         @thread_pool_size = processor.parallel_batches_executors
       else

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -49,7 +49,7 @@ module Racecar
     end
 
     def setup_multithreading
-      if !processor.parallel_batches_executors.nil? && processor.parallel_batches_executors > 0
+      if multi_threading_enabled?
         logger.info "Running with parallel batch processing with #{processor.parallel_batches_executors} threads"
         @thread_pool_size = processor.parallel_batches_executors
       else
@@ -336,6 +336,10 @@ module Racecar
       else
         block.call
       end
+    end
+
+    def multi_threading_enabled?
+      !processor.parallel_batches_executors.nil? && processor.parallel_batches_executors > 0
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -78,6 +78,23 @@ RSpec.describe Racecar::Config do
     }.to raise_exception(KingKonf::ConfigError)
   end
 
+  it "requires `shutdown_timeout` to be valid" do
+    expect {
+      config.shutdown_timeout = 30
+      config.validate!
+    }.not_to raise_exception
+
+    expect {
+      config.shutdown_timeout = -1
+      config.validate!
+    }.to raise_exception(Racecar::ConfigError)
+
+    expect {
+      config.shutdown_timeout = 0
+      config.validate!
+    }.to raise_exception(Racecar::ConfigError)
+  end
+
   describe "#load_env" do
     it "sets the brokers from RACECAR_BROKERS" do
       with_env("RACECAR_BROKERS", "hansel,gretel") do


### PR DESCRIPTION
This PR adds an optional opportunity to run a thread pool and allow threads to consume and process messages (and message batches) in parallel. Key changes:
- Added an optional parameter `self.parallel_batches_executors` in the Consumer class (accordingly to README.md). If this parameter is set and is valid, then the thread pool will be launched. If not, the default processing will be used.
- Added `thread_safe` method in the Consumer to wrap operations, which require thread-safeness
- Updated tests