### PR TITLE
[DRAFT] Add processing of partitions in a separate thread

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -194,6 +194,12 @@ module Racecar
     desc "Strategy for switching topics when there are multiple subscriptions. `exhaust-topic` will only switch when the consumer poll returns no messages. `round-robin` will switch after each poll regardless.\nWarning: `round-robin` will be the default in Racecar 3.x"
     string :multi_subscription_strategy, allowed_values: %w(round-robin exhaust-topic), default: "exhaust-topic"
 
+    desc "Determines if processing every partition per topic in separate threads is enabled"
+    boolean :partition_threading_enabled, default: false
+
+    desc "Max number of threads to process partitions in parallel. Only applies if `partition_threading_enabled` is enabled. Defaults to the number of partitions assigned to the consumer."
+    integer :max_parallel_threads
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -94,6 +94,12 @@ module Racecar
       @delivery_handles.clear
     end
 
+    def all_partition_ids
+      topics = subscriptions.map(&:topic)
+
+      topics.map { |topic| partitions_per_topic(topic) }.flatten.uniq
+    end
+
     protected
 
     # https://github.com/appsignal/rdkafka-ruby#producing-messages
@@ -127,6 +133,15 @@ module Racecar
 
     def heartbeat
       warn "DEPRECATION WARNING: Manual heartbeats are not supported and not needed with librdkafka."
+    end
+
+    def partitions_per_topic(topic)
+      result = []
+      @consumer&.each_subscribed do |consumer|
+        partitions = consumer.assignment.to_h[topic]&.map(&:partition) || []
+        result << partitions
+      end
+      result.flatten.uniq
     end
   end
 end

--- a/lib/racecar/consumer_factory.rb
+++ b/lib/racecar/consumer_factory.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Racecar
+  class ConsumerFactory
+    def initialize(consumer_class, config: Racecar.config, instrumenter: Racecar.config.instrumenter)
+      @consumer_class = consumer_class
+      @config = config
+      @instrumenter = instrumenter
+    end
+
+    def create_consumer_instance
+      @consumer_class.new
+    end
+
+    def configure_consumer_instance(consumer_instance, producer:, kafka_consumer:)
+      consumer_instance.configure(
+        producer: producer,
+        consumer: kafka_consumer,
+        instrumenter: @instrumenter,
+        config: @config
+      )
+      consumer_instance
+    end
+
+    attr_reader :consumer_class, :config, :instrumenter
+  end
+end

--- a/lib/racecar/partition_worker.rb
+++ b/lib/racecar/partition_worker.rb
@@ -1,0 +1,48 @@
+require "concurrent-ruby"
+require "racecar/pause_guarded_processing"
+
+module Racecar
+  class PartitionWorker < Concurrent::Actor::Context
+    attr_reader :processor, :producer, :consumer, :pauses, :logger, :config
+
+    include PauseGuardedProcessing
+
+    def initialize(args)
+      @processor = args[:processor]
+      @producer = @processor.producer
+      @consumer = @processor.consumer
+      @pauses = args[:pauses]
+      @logger = args[:logger]
+      @config = args[:config]
+      @instrumenter = args[:instrumenter]
+    end
+
+    def on_message(message)
+      case message
+      when Hash
+        case message[:action]
+        when 'process'
+          process_with_pause(message[:message])
+        when 'process_batch'
+          process_batch_with_pause(message[:messages])
+        else
+          Racecar.logger.warn "Unknown action '#{message[:action]}' received by a partition worker"
+        end
+      when :terminate!
+        handle_shutdown
+        :terminate!
+      else
+        Racecar.logger.warn "Unknown message received by a partition worker: #{message}"
+      end
+    end
+
+    private
+
+    def handle_shutdown
+      logger.info "Shutting down a partition worker..."
+      processor.deliver!
+      processor.teardown
+      consumer.thread_safe_commit
+    end
+  end
+end

--- a/lib/racecar/pause_guarded_processing.rb
+++ b/lib/racecar/pause_guarded_processing.rb
@@ -1,0 +1,158 @@
+require "rdkafka"
+
+module Racecar
+  module PauseGuardedProcessing
+
+    def process_with_pause(message)
+      instrumentation_payload = {
+        consumer_class: processor.class.to_s,
+        topic:          message.topic,
+        partition:      message.partition,
+        offset:         message.offset,
+        create_time:    message.timestamp,
+        key:            message.key,
+        value:          message.payload,
+        headers:        message.headers
+      }
+
+      @instrumenter.instrument("start_process_message", instrumentation_payload)
+      with_pause(message.topic, message.partition, message.offset..message.offset) do |pause|
+        begin
+          @instrumenter.instrument("process_message", instrumentation_payload) do
+            processor.process(Racecar::Message.new(message, retries_count: pause.pauses_count))
+            processor.deliver!
+            consumer.store_offset(message)
+          end
+        rescue => e
+          instrumentation_payload[:unrecoverable_delivery_error] = reset_producer_on_unrecoverable_delivery_errors(e)
+          instrumentation_payload[:retries_count] = pause.pauses_count
+          config.error_handler.call(e, instrumentation_payload)
+          raise e
+        end
+      end
+    end
+
+    def process_batch_with_pause(messages)
+      first, last = messages.first, messages.last
+      instrumentation_payload = {
+        consumer_class: processor.class.to_s,
+        topic:          first.topic,
+        partition:      first.partition,
+        first_offset:   first.offset,
+        last_offset:    last.offset,
+        last_create_time: last.timestamp,
+        message_count:  messages.size
+      }
+
+      @instrumenter.instrument("start_process_batch", instrumentation_payload)
+      with_pause(first.topic, first.partition, first.offset..last.offset) do |pause|
+        begin
+          @instrumenter.instrument("process_batch", instrumentation_payload) do
+            racecar_messages = messages.map do |message|
+              Racecar::Message.new(message, retries_count: pause.pauses_count)
+            end
+            processor.process_batch(racecar_messages)
+            processor.deliver!
+            consumer.store_offset(messages.last)
+          end
+        rescue => e
+          instrumentation_payload[:unrecoverable_delivery_error] = reset_producer_on_unrecoverable_delivery_errors(e)
+          instrumentation_payload[:retries_count] = pause.pauses_count
+          config.error_handler.call(e, instrumentation_payload)
+          raise e
+        end
+      end
+    end
+
+    def consumer
+      @consumer ||= begin
+                      ConsumerSet.new(config, logger, @instrumenter)
+                    end
+    end
+
+    def producer
+      @producer ||= Rdkafka::Config.new(producer_config).producer.tap do |producer|
+        producer.delivery_callback = Racecar::DeliveryCallback.new(instrumenter: @instrumenter)
+      end
+    end
+
+    private
+
+    def producer_config
+      # https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+      producer_config = {
+        "bootstrap.servers"      => config.brokers.join(","),
+        "client.id"              => config.client_id,
+        "statistics.interval.ms" => config.statistics_interval_ms,
+        "message.timeout.ms"     => config.message_timeout * 1000,
+        "partitioner"            => config.partitioner.to_s,
+      }
+
+      producer_config["compression.codec"] = config.producer_compression_codec.to_s unless config.producer_compression_codec.nil?
+      producer_config.merge!(config.rdkafka_producer)
+      producer_config
+    end
+
+    def with_pause(topic, partition, offsets)
+      pause = pauses[topic][partition]
+      return yield pause if config.pause_timeout == 0
+
+      begin
+        yield pause
+        # We've successfully processed a batch from the partition, so we can clear the pause.
+        pauses[topic][partition].reset!
+      rescue => e
+        desc = "#{topic}/#{partition}"
+        logger.error "Failed to process #{desc} at #{offsets}: #{e}"
+
+        logger.warn "Pausing partition #{desc} for #{pause.backoff_interval} seconds"
+        consumer.thread_safe_pause(topic, partition, offsets.first)
+        pause.pause!
+      end
+    end
+
+    # librdkafka will continue to try to deliver already queued messages, even if ruby-rdkafka
+    # raised before that. This method detects any unrecoverable errors and resets the producer
+    # as a last ditch effort.
+    # The function returns true if there were unrecoverable errors, or false otherwise.
+    def reset_producer_on_unrecoverable_delivery_errors(error)
+      return false unless error.is_a?(Racecar::MessageDeliveryError)
+      return false unless error.code == :msg_timed_out # -192
+
+      logger.error error.to_s
+      logger.error "Racecar will reset the producer to force a new broker connection."
+      @producer.close
+      @producer = nil
+      processor.configure(
+        producer:     producer,
+        consumer:     consumer,
+        instrumenter: @instrumenter,
+        config:       @config,
+        )
+      true
+    end
+
+    def resume_paused_partitions
+      return if config.pause_timeout == 0
+
+      pauses.each do |topic, partitions|
+        partitions.each do |partition, pause|
+          instrumentation_payload = {
+            topic:      topic,
+            partition:  partition,
+            duration:   pause.pause_duration,
+            consumer_class: processor.class.to_s,
+          }
+          @instrumenter.instrument("pause_status", instrumentation_payload)
+
+          if pause.paused? && pause.expired?
+            logger.info "Automatically resuming partition #{topic}/#{partition}, pause timeout expired"
+            consumer.thread_safe_resume(topic, partition)
+            pause.resume!
+            # TODO: # During re-balancing we might have lost the paused partition. Check if partition is still in group before seek. ?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -6,15 +6,22 @@ require "racecar/message"
 require "racecar/message_delivery_error"
 require "racecar/erroneous_state_error"
 require "racecar/delivery_callback"
+require "racecar/consumer_factory"
+require "racecar/pause_guarded_processing"
+require "racecar/partition_worker"
 
 module Racecar
   class Runner
     attr_reader :processor, :config, :logger
 
+    include PauseGuardedProcessing
+
     def initialize(processor, config:, logger:, instrumenter: NullInstrumenter)
       @processor, @config, @logger = processor, config, logger
       @instrumenter = instrumenter
       @stop_requested = false
+      @workers = {}
+      @consumer_factory = ConsumerFactory.new(processor.class, config: config, instrumenter: instrumenter)
       Rdkafka::Config.logger = logger
 
       if processor.respond_to?(:statistics_callback)
@@ -22,6 +29,22 @@ module Racecar
       end
 
       setup_pauses
+    end
+
+    def setup_multithreading
+      if config.partition_threading_enabled
+        consumer.subscribe_all
+        partitions = processor.all_partition_ids
+        if config.max_parallel_threads
+          @max_threads = config.max_parallel_threads
+        else
+          @max_threads = partitions.size
+        end
+        workers_array_cycle = @max_threads.times.map { create_worker }.cycle
+        partitions.each do |partition_id|
+          @workers[partition_id] = workers_array_cycle.next
+        end
+      end
     end
 
     def setup_pauses
@@ -64,6 +87,8 @@ module Racecar
         consumer_set: consumer
       }
 
+      setup_multithreading
+
       # Main loop
       loop do
         break if @stop_requested
@@ -75,11 +100,35 @@ module Racecar
           when :batch then
             msg_per_part = consumer.batch_poll(config.max_wait_time_ms).group_by(&:partition)
             msg_per_part.each_value do |messages|
-              process_batch(messages)
+              if config.partition_threading_enabled
+                first = messages.first
+                partition = first.partition
+                worker = @workers[partition]
+                if worker
+                  worker << { action: 'process_batch', messages: messages }
+                else
+                  logger.warn "No worker found for partition #{partition}, processing batch in main thread"
+                  process_batch_with_pause(messages)
+                end
+              else
+                process_batch_with_pause(messages)
+              end
+
             end
           when :single then
             message = consumer.poll(config.max_wait_time_ms)
-            process(message) if message
+            if config.partition_threading_enabled && message
+              partition = message.partition
+              worker = @workers[partition]
+              if worker
+                worker << { action: 'process', message: message }
+              else
+                logger.warn "No worker found for partition #{partition}, processing message in main thread"
+                process_with_pause(message) if message
+              end
+            else
+              process_with_pause(message) if message
+            end
           end
         end
       end
@@ -88,7 +137,10 @@ module Racecar
       begin
         processor.deliver!
         processor.teardown
-        consumer.commit
+        consumer.thread_safe_commit
+        if config.partition_threading_enabled
+          shutdown_workers
+        end
       ensure
         @instrumenter.instrument('leave_group') do
           consumer.close
@@ -102,6 +154,15 @@ module Racecar
 
     def stop
       @stop_requested = true
+    end
+
+    def shutdown_workers
+      if config.partition_threading_enabled
+        @workers.each do |partition_id, worker|
+          logger.info "Shutting down worker for partition #{partition_id}"
+          worker.ask!(:terminate!)
+        end
+      end
     end
 
     private
@@ -129,31 +190,21 @@ module Racecar
       end
     end
 
-    def consumer
-      @consumer ||= begin
-        ConsumerSet.new(config, logger, @instrumenter)
-      end
-    end
-
-    def producer
-      @producer ||= Rdkafka::Config.new(producer_config).producer.tap do |producer|
-        producer.delivery_callback = Racecar::DeliveryCallback.new(instrumenter: @instrumenter)
-      end
-    end
-
-    def producer_config
-      # https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
-      producer_config = {
-        "bootstrap.servers"      => config.brokers.join(","),
-        "client.id"              => config.client_id,
-        "statistics.interval.ms" => config.statistics_interval_ms,
-        "message.timeout.ms"     => config.message_timeout * 1000,
-        "partitioner"            => config.partitioner.to_s,
-      }
-
-      producer_config["compression.codec"] = config.producer_compression_codec.to_s unless config.producer_compression_codec.nil?
-      producer_config.merge!(config.rdkafka_producer)
-      producer_config
+    def create_worker
+      processor_instance = @consumer_factory.create_consumer_instance
+      processor_instance.configure(
+        producer:     producer,
+        consumer:     consumer,
+        instrumenter: @instrumenter,
+        config:       @config,
+        )
+      PartitionWorker.spawn(args: {
+        processor: processor_instance,
+        pauses: pauses,
+        logger: logger,
+        config: config,
+        instrumenter: @instrumenter,
+      })
     end
 
     def install_signal_handlers
@@ -164,130 +215,6 @@ module Racecar
 
       # Print the consumer config to STDERR on USR1.
       trap("USR1") { $stderr.puts config.inspect }
-    end
-
-    def process(message)
-      instrumentation_payload = {
-        consumer_class: processor.class.to_s,
-        topic:          message.topic,
-        partition:      message.partition,
-        offset:         message.offset,
-        create_time:    message.timestamp,
-        key:            message.key,
-        value:          message.payload,
-        headers:        message.headers
-      }
-
-      @instrumenter.instrument("start_process_message", instrumentation_payload)
-      with_pause(message.topic, message.partition, message.offset..message.offset) do |pause|
-        begin
-          @instrumenter.instrument("process_message", instrumentation_payload) do
-            processor.process(Racecar::Message.new(message, retries_count: pause.pauses_count))
-            processor.deliver!
-            consumer.store_offset(message)
-          end
-        rescue => e
-          instrumentation_payload[:unrecoverable_delivery_error] = reset_producer_on_unrecoverable_delivery_errors(e)
-          instrumentation_payload[:retries_count] = pause.pauses_count
-          config.error_handler.call(e, instrumentation_payload)
-          raise e
-        end
-      end
-    end
-
-    def process_batch(messages)
-      first, last = messages.first, messages.last
-      instrumentation_payload = {
-        consumer_class: processor.class.to_s,
-        topic:          first.topic,
-        partition:      first.partition,
-        first_offset:   first.offset,
-        last_offset:    last.offset,
-        last_create_time: last.timestamp,
-        message_count:  messages.size
-      }
-
-      @instrumenter.instrument("start_process_batch", instrumentation_payload)
-      with_pause(first.topic, first.partition, first.offset..last.offset) do |pause|
-        begin
-          @instrumenter.instrument("process_batch", instrumentation_payload) do
-            racecar_messages = messages.map do |message|
-              Racecar::Message.new(message, retries_count: pause.pauses_count)
-            end
-            processor.process_batch(racecar_messages)
-            processor.deliver!
-            consumer.store_offset(messages.last)
-          end
-        rescue => e
-          instrumentation_payload[:unrecoverable_delivery_error] = reset_producer_on_unrecoverable_delivery_errors(e)
-          instrumentation_payload[:retries_count] = pause.pauses_count
-          config.error_handler.call(e, instrumentation_payload)
-          raise e
-        end
-      end
-    end
-
-    # librdkafka will continue to try to deliver already queued messages, even if ruby-rdkafka
-    # raised before that. This method detects any unrecoverable errors and resets the producer
-    # as a last ditch effort.
-    # The function returns true if there were unrecoverable errors, or false otherwise.
-    def reset_producer_on_unrecoverable_delivery_errors(error)
-      return false unless error.is_a?(Racecar::MessageDeliveryError)
-      return false unless error.code == :msg_timed_out # -192
-
-      logger.error error.to_s
-      logger.error "Racecar will reset the producer to force a new broker connection."
-      @producer.close
-      @producer = nil
-      processor.configure(
-        producer:     producer,
-        consumer:     consumer,
-        instrumenter: @instrumenter,
-        config:       @config,
-      )
-
-      true
-    end
-
-    def with_pause(topic, partition, offsets)
-      pause = pauses[topic][partition]
-      return yield pause if config.pause_timeout == 0
-
-      begin
-        yield pause
-        # We've successfully processed a batch from the partition, so we can clear the pause.
-        pauses[topic][partition].reset!
-      rescue => e
-        desc = "#{topic}/#{partition}"
-        logger.error "Failed to process #{desc} at #{offsets}: #{e}"
-
-        logger.warn "Pausing partition #{desc} for #{pause.backoff_interval} seconds"
-        consumer.pause(topic, partition, offsets.first)
-        pause.pause!
-      end
-    end
-
-    def resume_paused_partitions
-      return if config.pause_timeout == 0
-
-      pauses.each do |topic, partitions|
-        partitions.each do |partition, pause|
-          instrumentation_payload = {
-            topic:      topic,
-            partition:  partition,
-            duration:   pause.pause_duration,
-            consumer_class: processor.class.to_s,
-          }
-          @instrumenter.instrument("pause_status", instrumentation_payload)
-
-          if pause.paused? && pause.expired?
-            logger.info "Automatically resuming partition #{topic}/#{partition}, pause timeout expired"
-            consumer.resume(topic, partition)
-            pause.resume!
-            # TODO: # During re-balancing we might have lost the paused partition. Check if partition is still in group before seek. ?
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
This PR adds an option to enable processing of every partition in a separate thread. Key changes:
- spawning actors from `concurrent-ruby` library
- every actor is responsible for processing messages coming from a single partition
- the default limit number of threads is equal to number of subscribed partitions, but can be lowered by a dedicated config value
- If multi-threading feature is disabled, the code flow is the same as it was before