### PR TITLE
Add threading based on consumer groups [Attempt 3]

### DIFF
--- a/lib/racecar.rb
+++ b/lib/racecar.rb
@@ -8,6 +8,7 @@ require "racecar/consumer"
 require "racecar/consumer_set"
 require "racecar/runner"
 require "racecar/parallel_runner"
+require "racecar/threaded_runner"
 require "racecar/producer"
 require "racecar/config"
 require "racecar/version"
@@ -70,12 +71,18 @@ module Racecar
   end
 
   def self.runner(processor)
-    runner = Runner.new(processor, config: config, logger: logger, instrumenter: config.instrumenter)
-
-    if config.parallel_workers && config.parallel_workers > 1
+    if config.threaded
+      ThreadedRunner.new(
+        consumer_class: config.consumer_class,
+        config: config,
+        logger: logger,
+        instrumenter: config.instrumenter
+      )
+    elsif config.parallel_workers && config.parallel_workers > 1
+      runner = Runner.new(processor, config: config, logger: logger, instrumenter: config.instrumenter)
       ParallelRunner.new(runner: runner, config: config, logger: logger)
     else
-      runner
+      Runner.new(processor, config: config, logger: logger, instrumenter: config.instrumenter)
     end
   end
 end

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -197,7 +197,7 @@ module Racecar
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 
-    attr_accessor :subscriptions, :logger, :parallel_workers, :threaded
+    attr_accessor :subscriptions, :logger, :parallel_workers, :threaded, :dynamic_partition_scaling
 
     def statistics_interval_ms
       if Rdkafka::Config.statistics_callback
@@ -241,6 +241,10 @@ module Racecar
       if threaded && parallel_workers && parallel_workers > 1
         raise ConfigError, "`threaded` and `parallel_workers` cannot be used together"
       end
+
+      if dynamic_partition_scaling && !threaded
+        raise ConfigError, "`dynamic_partition_scaling` requires `threaded` to be enabled"
+      end
     end
 
     def load_consumer_class(consumer_class)
@@ -257,6 +261,7 @@ module Racecar
 
       self.parallel_workers = consumer_class.parallel_workers
       self.threaded = consumer_class.threaded
+      self.dynamic_partition_scaling = consumer_class.dynamic_partition_scaling
       self.subscriptions = consumer_class.subscriptions
       self.max_wait_time = consumer_class.max_wait_time || self.max_wait_time
       self.fetch_messages = consumer_class.fetch_messages || self.fetch_messages

--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -197,7 +197,7 @@ module Racecar
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 
-    attr_accessor :subscriptions, :logger, :parallel_workers
+    attr_accessor :subscriptions, :logger, :parallel_workers, :threaded
 
     def statistics_interval_ms
       if Rdkafka::Config.statistics_callback
@@ -237,6 +237,10 @@ module Racecar
       if max_pause_timeout && !pause_with_exponential_backoff?
         raise ConfigError, "`max_pause_timeout` only makes sense when `pause_with_exponential_backoff` is enabled"
       end
+
+      if threaded && parallel_workers && parallel_workers > 1
+        raise ConfigError, "`threaded` and `parallel_workers` cannot be used together"
+      end
     end
 
     def load_consumer_class(consumer_class)
@@ -252,6 +256,7 @@ module Racecar
       ].compact.join
 
       self.parallel_workers = consumer_class.parallel_workers
+      self.threaded = consumer_class.threaded
       self.subscriptions = consumer_class.subscriptions
       self.max_wait_time = consumer_class.max_wait_time || self.max_wait_time
       self.fetch_messages = consumer_class.fetch_messages || self.fetch_messages

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -9,7 +9,7 @@ module Racecar
     class << self
       attr_accessor :max_wait_time
       attr_accessor :group_id
-      attr_accessor :producer, :consumer, :parallel_workers, :fetch_messages
+      attr_accessor :producer, :consumer, :parallel_workers, :fetch_messages, :threaded
 
       def subscriptions
         @subscriptions ||= []

--- a/lib/racecar/consumer.rb
+++ b/lib/racecar/consumer.rb
@@ -9,7 +9,7 @@ module Racecar
     class << self
       attr_accessor :max_wait_time
       attr_accessor :group_id
-      attr_accessor :producer, :consumer, :parallel_workers, :fetch_messages, :threaded
+      attr_accessor :producer, :consumer, :parallel_workers, :fetch_messages, :threaded, :dynamic_partition_scaling
 
       def subscriptions
         @subscriptions ||= []

--- a/lib/racecar/threaded_runner.rb
+++ b/lib/racecar/threaded_runner.rb
@@ -5,6 +5,7 @@ require "rdkafka"
 module Racecar
   class ThreadedRunner
     SHUTDOWN_SIGNALS = ["INT", "QUIT", "TERM"]
+    METADATA_POLL_INTERVAL = 60
 
     def initialize(consumer_class:, config:, logger:, instrumenter:)
       @consumer_class = consumer_class
@@ -13,6 +14,8 @@ module Racecar
       @instrumenter = instrumenter
       @runners = []
       @threads = []
+      @mutex = Mutex.new
+      @stop_requested = false
       @thread_error = nil
     end
 
@@ -22,25 +25,12 @@ module Racecar
 
     def run
       partition_counts = fetch_partition_counts
-      thread_count = partition_counts.values.max
+      @current_thread_count = partition_counts.values.max
       partition_counts.each { |topic, count| logger.info "=> Discovered #{count} partitions for topic '#{topic}'" }
-      logger.info "=> Starting #{thread_count} threaded consumers"
+      logger.info "=> Starting #{@current_thread_count} threaded consumers"
 
-      @runners = thread_count.times.map do
-        processor = consumer_class.new
-        Runner.new(processor, config: config, logger: logger, instrumenter: instrumenter)
-      end
-
-      @threads = @runners.each_with_index.map do |runner, i|
-        Thread.new do
-          Thread.current.name = "racecar-thread-#{i}"
-          runner.run
-        rescue Exception => e
-          logger.error "Thread #{i} crashed: #{e.class}: #{e.message}"
-          @thread_error ||= e
-          stop
-        end
-      end
+      spawn_runners(@current_thread_count)
+      start_metadata_watcher if config.dynamic_partition_scaling
 
       install_signal_handlers
 
@@ -50,16 +40,65 @@ module Racecar
     end
 
     def stop
-      @runners.each(&:stop)
+      @stop_requested = true
+      @mutex.synchronize { @runners.each(&:stop) }
     end
 
     private
 
     attr_reader :consumer_class, :config, :logger, :instrumenter
 
+    def spawn_runners(count)
+      count.times do
+        processor = consumer_class.new
+        runner = Runner.new(processor, config: config, logger: logger, instrumenter: instrumenter)
+        thread = spawn_thread(runner)
+        @mutex.synchronize do
+          @runners << runner
+          @threads << thread
+        end
+      end
+    end
+
+    def spawn_thread(runner)
+      index = @mutex.synchronize { @threads.size }
+      Thread.new do
+        Thread.current.name = "racecar-thread-#{index}"
+        runner.run
+      rescue Exception => e
+        logger.error "Thread #{index} crashed: #{e.class}: #{e.message}"
+        @thread_error ||= e
+        stop
+      end
+    end
+
     def install_signal_handlers
       SHUTDOWN_SIGNALS.each { |signal| trap(signal) { stop } }
       trap("USR1") { $stderr.puts config.inspect }
+    end
+
+    def start_metadata_watcher
+      @watcher_thread = Thread.new do
+        Thread.current.name = "racecar-metadata-watcher"
+        until @stop_requested
+          sleep(METADATA_POLL_INTERVAL)
+          break if @stop_requested
+          check_for_new_partitions
+        end
+      end
+    end
+
+    def check_for_new_partitions
+      new_counts = fetch_partition_counts
+      new_max = new_counts.values.max
+      delta = new_max - @current_thread_count
+      return unless delta > 0
+
+      logger.info "=> Partition count increased to #{new_max}, spawning #{delta} new threads"
+      spawn_runners(delta)
+      @current_thread_count = new_max
+    rescue => e
+      logger.warn "Metadata poll failed: #{e.message}"
     end
 
     def fetch_partition_counts

--- a/lib/racecar/threaded_runner.rb
+++ b/lib/racecar/threaded_runner.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rdkafka"
+
+module Racecar
+  class ThreadedRunner
+    SHUTDOWN_SIGNALS = ["INT", "QUIT", "TERM"]
+
+    def initialize(consumer_class:, config:, logger:, instrumenter:)
+      @consumer_class = consumer_class
+      @config = config
+      @logger = logger
+      @instrumenter = instrumenter
+      @runners = []
+      @threads = []
+      @thread_error = nil
+    end
+
+    def running?
+      @threads.any?(&:alive?)
+    end
+
+    def run
+      partition_counts = fetch_partition_counts
+      thread_count = partition_counts.values.max
+      partition_counts.each { |topic, count| logger.info "=> Discovered #{count} partitions for topic '#{topic}'" }
+      logger.info "=> Starting #{thread_count} threaded consumers"
+
+      @runners = thread_count.times.map do
+        processor = consumer_class.new
+        Runner.new(processor, config: config, logger: logger, instrumenter: instrumenter)
+      end
+
+      @threads = @runners.each_with_index.map do |runner, i|
+        Thread.new do
+          Thread.current.name = "racecar-thread-#{i}"
+          runner.run
+        rescue Exception => e
+          logger.error "Thread #{i} crashed: #{e.class}: #{e.message}"
+          @thread_error ||= e
+          stop
+        end
+      end
+
+      install_signal_handlers
+
+      @threads.each(&:join)
+
+      raise @thread_error if @thread_error
+    end
+
+    def stop
+      @runners.each(&:stop)
+    end
+
+    private
+
+    attr_reader :consumer_class, :config, :logger, :instrumenter
+
+    def install_signal_handlers
+      SHUTDOWN_SIGNALS.each { |signal| trap(signal) { stop } }
+      trap("USR1") { $stderr.puts config.inspect }
+    end
+
+    def fetch_partition_counts
+      metadata_config = {
+        "bootstrap.servers" => config.brokers.join(","),
+        "group.id" => config.group_id,
+      }.merge(config.rdkafka_consumer)
+
+      consumer = Rdkafka::Config.new(metadata_config).consumer
+      native_kafka = consumer.instance_variable_get(:@native_kafka)
+
+      counts = {}
+      config.subscriptions.each do |subscription|
+        topic_metadata = nil
+        native_kafka.with_inner do |inner|
+          topic_metadata = ::Rdkafka::Metadata.new(inner, subscription.topic).topics&.first
+        end
+        count = topic_metadata ? topic_metadata[:partition_count] : 0
+        raise Racecar::Error, "Could not discover partitions for topic '#{subscription.topic}'" if count <= 0
+        counts[subscription.topic] = count
+      end
+
+      consumer.close
+      counts
+    end
+  end
+end

--- a/spec/threaded_runner_spec.rb
+++ b/spec/threaded_runner_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "racecar/threaded_runner"
+
+RSpec.describe Racecar::ThreadedRunner do
+  let(:config) do
+    Racecar::Config.new.tap do |c|
+      c.subscriptions = subscriptions
+      c.group_id = "test-group"
+      c.threaded = true
+    end
+  end
+  let(:subscriptions) { [Racecar::Consumer::Subscription.new("test-topic", true, 1048576, {})] }
+  let(:logger) { Logger.new(StringIO.new) }
+  let(:instrumenter) { Racecar::NullInstrumenter }
+
+  let(:consumer_class) do
+    Class.new(Racecar::Consumer) do
+      subscribes_to "test-topic"
+
+      def process(message)
+      end
+    end
+  end
+
+  let(:threaded_runner) do
+    described_class.new(
+      consumer_class: consumer_class,
+      config: config,
+      logger: logger,
+      instrumenter: instrumenter
+    )
+  end
+
+  describe "#run" do
+    context "with a single topic" do
+      before do
+        allow(threaded_runner).to receive(:fetch_partition_counts).and_return({ "test-topic" => 3 })
+      end
+
+      it "creates one runner per partition and joins all threads" do
+        runners = []
+        allow(Racecar::Runner).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+          method.call(*args, **kwargs).tap do |runner|
+            runners << runner
+            allow(runner).to receive(:run) { sleep 0.05 }
+            allow(runner).to receive(:stop)
+          end
+        end
+
+        threaded_runner.run
+
+        expect(runners.size).to eq(3)
+      end
+
+      it "stops all runners when stop is called" do
+        runners = []
+        allow(Racecar::Runner).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+          method.call(*args, **kwargs).tap do |runner|
+            runners << runner
+            allow(runner).to receive(:run) do
+              sleep 0.1 until runner.instance_variable_get(:@stop_requested)
+            end
+          end
+        end
+
+        Thread.new do
+          sleep 0.1
+          threaded_runner.stop
+        end
+
+        threaded_runner.run
+
+        runners.each do |runner|
+          expect(runner.instance_variable_get(:@stop_requested)).to eq(true)
+        end
+      end
+    end
+
+    context "with multiple topics" do
+      let(:subscriptions) do
+        [
+          Racecar::Consumer::Subscription.new("topic-a", true, 1048576, {}),
+          Racecar::Consumer::Subscription.new("topic-b", true, 1048576, {}),
+        ]
+      end
+
+      before do
+        allow(threaded_runner).to receive(:fetch_partition_counts).and_return({
+          "topic-a" => 3,
+          "topic-b" => 5,
+        })
+      end
+
+      it "uses the max partition count across topics" do
+        runners = []
+        allow(Racecar::Runner).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+          method.call(*args, **kwargs).tap do |runner|
+            runners << runner
+            allow(runner).to receive(:run) { sleep 0.05 }
+            allow(runner).to receive(:stop)
+          end
+        end
+
+        threaded_runner.run
+
+        expect(runners.size).to eq(5)
+      end
+    end
+
+    context "when a thread raises an error" do
+      before do
+        allow(threaded_runner).to receive(:fetch_partition_counts).and_return({ "test-topic" => 2 })
+      end
+
+      it "propagates the error after stopping all threads" do
+        call_count = 0
+        allow(Racecar::Runner).to receive(:new).and_wrap_original do |method, *args, **kwargs|
+          method.call(*args, **kwargs).tap do |runner|
+            current_count = (call_count += 1)
+            allow(runner).to receive(:run) do
+              if current_count == 1
+                raise RuntimeError, "Thread crashed"
+              else
+                sleep 0.1 until runner.instance_variable_get(:@stop_requested)
+              end
+            end
+            allow(runner).to receive(:stop) do
+              runner.instance_variable_set(:@stop_requested, true)
+            end
+          end
+        end
+
+        expect { threaded_runner.run }.to raise_error(RuntimeError, "Thread crashed")
+      end
+    end
+
+    context "when partition count is 0" do
+      before do
+        mock_consumer = double("rdkafka_consumer")
+        mock_native_kafka = double("native_kafka")
+        mock_config = double("rdkafka_config", consumer: mock_consumer)
+
+        allow(Rdkafka::Config).to receive(:new).and_return(mock_config)
+        allow(mock_consumer).to receive(:instance_variable_get).with(:@native_kafka).and_return(mock_native_kafka)
+        allow(mock_native_kafka).to receive(:with_inner).and_yield(double("inner"))
+        allow(Rdkafka::Metadata).to receive(:new).and_return(double(topics: [{ partition_count: 0 }]))
+        allow(mock_consumer).to receive(:close)
+      end
+
+      it "raises an error" do
+        expect { threaded_runner.run }.to raise_error(Racecar::Error, /Could not discover partitions/)
+      end
+    end
+  end
+
+  describe "#running?" do
+    it "returns false when not started" do
+      expect(threaded_runner.running?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds multithreading into the Racecar based on consumer groups mechanism.
Key changes:
- Added an option for users to enable this feature on purpose. If the option is switched off, then a usual data flow would be used.
- Adds multithreading:
  1. In a first step, the Racecar consumer is discovering the number of partitions used by every subscribed topic (based on Rdkafka API)
  2. Then spawn the exact number of threads to cover all partitions 1 by 1.
  3. Every spawned thread will have a kafka consumer attached and all spawned consumers are belonging to the same consumer group, which allows Kafka to scale using it's own mechanisms
  4. Optionally, if a user enables `dynamic_partition_scaling`, then one another thread is being spawned, which polls the number of partitions every 60 seconds. If the number of partitions exceeds the current size of a thread pool, we're spawning more of them to cover all partitions