### PR TITLE
[Roll out of 3.0.0 Part 1] Add Partition Processor and fix flakky tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+# 2.13.0
+* Move the per-message/per-batch processing and its instrumentation out of Runner and into a dedicated PartitionProcessor
+
 ## 2.12.0
 
 * Add tests against Ruby 3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    racecar (2.12.0)
+    racecar (2.13.0)
       king_konf (~> 1.0.0)
       rdkafka (>= 0.15.0)
 
@@ -81,4 +81,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.6.2
+   2.6.9

--- a/lib/racecar/partition_processor.rb
+++ b/lib/racecar/partition_processor.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "racecar/message"
+
+module Racecar
+  class PartitionProcessor
+    def initialize(processor:, consumer:, instrumenter:)
+      @processor = processor
+      @consumer = consumer
+      @instrumenter = instrumenter
+    end
+
+    def message_payload(message)
+      {
+        consumer_class: @processor.class.to_s,
+        topic:          message.topic,
+        partition:      message.partition,
+        offset:         message.offset,
+        create_time:    message.timestamp,
+        key:            message.key,
+        value:          message.payload,
+        headers:        message.headers,
+      }
+    end
+
+    def batch_payload(messages)
+      first, last = messages.first, messages.last
+      {
+        consumer_class:   @processor.class.to_s,
+        topic:            first.topic,
+        partition:        first.partition,
+        first_offset:     first.offset,
+        last_offset:      last.offset,
+        last_create_time: last.timestamp,
+        message_count:    messages.size,
+      }
+    end
+
+    def process(message, retries_count, payload)
+      @instrumenter.instrument("process_message", payload) do
+        @processor.process(Racecar::Message.new(message, retries_count: retries_count))
+        @processor.deliver!
+        @consumer.store_offset(message)
+      end
+    end
+
+    def process_batch(messages, retries_count, payload)
+      @instrumenter.instrument("process_batch", payload) do
+        racecar_messages = messages.map do |message|
+          Racecar::Message.new(message, retries_count: retries_count)
+        end
+        @processor.process_batch(racecar_messages)
+        @processor.deliver!
+        @consumer.store_offset(messages.last)
+      end
+    end
+  end
+end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -6,6 +6,7 @@ require "racecar/message"
 require "racecar/message_delivery_error"
 require "racecar/erroneous_state_error"
 require "racecar/delivery_callback"
+require "racecar/partition_processor"
 
 module Racecar
   class Runner
@@ -15,6 +16,7 @@ module Racecar
       @processor, @config, @logger = processor, config, logger
       @instrumenter = instrumenter
       @stop_requested = false
+      @partition_processors = Hash.new
       Rdkafka::Config.logger = logger
 
       if processor.respond_to?(:statistics_callback)
@@ -22,6 +24,10 @@ module Racecar
       end
 
       setup_pauses
+    end
+
+    def self.topic_partition_key(topic, partition)
+      "#{topic}/#{partition}"
     end
 
     def setup_pauses
@@ -135,6 +141,15 @@ module Racecar
       end
     end
 
+    def assign_and_get_processor(messages)
+      topic     = messages.is_a?(Array) ? messages.first.topic     : messages.topic
+      partition = messages.is_a?(Array) ? messages.first.partition : messages.partition
+      key = Runner.topic_partition_key(topic, partition)
+      return @partition_processors[key] if @partition_processors[key]
+
+      @partition_processors[key] = PartitionProcessor.new(processor: processor, consumer: consumer, instrumenter: @instrumenter)
+    end
+
     def producer
       @producer ||= Rdkafka::Config.new(producer_config).producer.tap do |producer|
         producer.delivery_callback = Racecar::DeliveryCallback.new(instrumenter: @instrumenter)
@@ -167,25 +182,13 @@ module Racecar
     end
 
     def process(message)
-      instrumentation_payload = {
-        consumer_class: processor.class.to_s,
-        topic:          message.topic,
-        partition:      message.partition,
-        offset:         message.offset,
-        create_time:    message.timestamp,
-        key:            message.key,
-        value:          message.payload,
-        headers:        message.headers
-      }
+      processor = assign_and_get_processor(message)
+      instrumentation_payload = processor.message_payload(message)
 
       @instrumenter.instrument("start_process_message", instrumentation_payload)
       with_pause(message.topic, message.partition, message.offset..message.offset) do |pause|
         begin
-          @instrumenter.instrument("process_message", instrumentation_payload) do
-            processor.process(Racecar::Message.new(message, retries_count: pause.pauses_count))
-            processor.deliver!
-            consumer.store_offset(message)
-          end
+          processor.process(message, pause.pauses_count, instrumentation_payload)
         rescue => e
           instrumentation_payload[:unrecoverable_delivery_error] = reset_producer_on_unrecoverable_delivery_errors(e)
           instrumentation_payload[:retries_count] = pause.pauses_count
@@ -196,28 +199,14 @@ module Racecar
     end
 
     def process_batch(messages)
-      first, last = messages.first, messages.last
-      instrumentation_payload = {
-        consumer_class: processor.class.to_s,
-        topic:          first.topic,
-        partition:      first.partition,
-        first_offset:   first.offset,
-        last_offset:    last.offset,
-        last_create_time: last.timestamp,
-        message_count:  messages.size
-      }
+      processor = assign_and_get_processor(messages)
+      instrumentation_payload = processor.batch_payload(messages)
 
       @instrumenter.instrument("start_process_batch", instrumentation_payload)
-      with_pause(first.topic, first.partition, first.offset..last.offset) do |pause|
+      first = messages.first
+      with_pause(first.topic, first.partition, first.offset..messages.last.offset) do |pause|
         begin
-          @instrumenter.instrument("process_batch", instrumentation_payload) do
-            racecar_messages = messages.map do |message|
-              Racecar::Message.new(message, retries_count: pause.pauses_count)
-            end
-            processor.process_batch(racecar_messages)
-            processor.deliver!
-            consumer.store_offset(messages.last)
-          end
+          processor.process_batch(messages, pause.pauses_count, instrumentation_payload)
         rescue => e
           instrumentation_payload[:unrecoverable_delivery_error] = reset_producer_on_unrecoverable_delivery_errors(e)
           instrumentation_payload[:retries_count] = pause.pauses_count

--- a/lib/racecar/version.rb
+++ b/lib/racecar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Racecar
-  VERSION = "2.12.0"
+  VERSION = "2.13.0"
 end

--- a/spec/integration/cooperative_sticky_assignment_spec.rb
+++ b/spec/integration/cooperative_sticky_assignment_spec.rb
@@ -41,12 +41,13 @@ RSpec.describe "cooperative-sticky assignment", type: :integration do
       publish_messages
       wait_for_a_few_messages
 
+      revocations_before_termination = revocation_events.dup
       terminate_consumer1
 
       wait_for_all_messages
 
       aggregate_failures do
-        expect_consumer0_did_not_have_partitions_revoked_but_consumer1_did
+        expect_consumer0_did_not_have_partitions_revoked_but_consumer1_did(revocations_before_termination)
         expect_consumer0_took_over_processing_from_consumer1
       end
     end
@@ -61,10 +62,11 @@ RSpec.describe "cooperative-sticky assignment", type: :integration do
       expect(consumer0_partitions).to include(consumer1_partition)
     end
 
-    def expect_consumer0_did_not_have_partitions_revoked_but_consumer1_did
-      revocations_by_consumer_thread_id = revocation_events.group_by { |e| e.fetch("consumer_id") }
+    def expect_consumer0_did_not_have_partitions_revoked_but_consumer1_did(revocations_before_termination)
+      revocations_after_termination = revocation_events - revocations_before_termination
 
-      revocations_by_consumer_index = revocations_by_consumer_thread_id
+      revocations_by_consumer_index = revocations_after_termination
+        .group_by { |e| e.fetch("consumer_id") }
         .transform_keys { |consumer_id| consumer_index_by_id.fetch(consumer_id) }
 
       expect(revocations_by_consumer_index.keys).to eq([1])


### PR DESCRIPTION
## What Changes

Extract message processing and instrumentation into PartitionProcessor; fix flakky test
Move the per-message/per-batch processing and its instrumentation out of
Runner and into a dedicated PartitionProcessor:

- PartitionProcessor builds the instrumentation payloads (message_payload/
  batch_payload), wraps processing in the process_message/process_batch
  instrumentation, runs the consumer's process/process_batch, flushes the
  producer and stores the offset.
- Runner keeps a map of PartitionProcessors keyed by topic/partition
  (assign_and_get_processor) and delegates the actual processing to them,
  while retaining ownership of pausing and the producer-reset error
  handling.

Also, tests in ./spec/integration/cooperative_sticky_assignment_spec.rb are flakky,
so this commit contains also a fix for them

Pausing, error handling and producer lifecycle stay in Runner for now.
Behaviour-preserving for the single-threaded path. All unit specs pass.

## Breaking Changes

* No