### PR TITLE
Add single_consumer config

### DIFF
--- a/lib/racecar/config.rb
+++ b/lib/racecar/config.rb
@@ -194,6 +194,9 @@ module Racecar
     desc "Strategy for switching topics when there are multiple subscriptions. `exhaust-topic` will only switch when the consumer poll returns no messages. `round-robin` will switch after each poll regardless.\nWarning: `round-robin` will be the default in Racecar 3.x"
     string :multi_subscription_strategy, allowed_values: %w(round-robin exhaust-topic), default: "exhaust-topic"
 
+    desc "Whether to subscribe to all topics from a single Kafka consumer, rather than one consumer per subscription. Requires all subscriptions to use the same start_from_beginning, max_bytes_per_partition and additional_config"
+    boolean :single_consumer, default: false
+
     # The error handler must be set directly on the object.
     attr_reader :error_handler
 

--- a/lib/racecar/consumer_set.rb
+++ b/lib/racecar/consumer_set.rb
@@ -10,7 +10,8 @@ module Racecar
       raise ArgumentError, "Subscriptions must not be empty when subscribing" if @config.subscriptions.empty?
 
       @consumers = []
-      @consumer_id_iterator = (0...@config.subscriptions.size).cycle
+      @subscriptions_by_consumer = subscriptions_by_consumer
+      @consumer_id_iterator = (0...@subscriptions_by_consumer.size).cycle
 
       @previous_retries = 0
 
@@ -71,14 +72,15 @@ module Racecar
 
     def current
       @consumers[@consumer_id_iterator.peek] ||= begin
-        consumer_config = Rdkafka::Config.new(rdkafka_config(current_subscription))
+        subscriptions = current_subscriptions
+        consumer_config = Rdkafka::Config.new(rdkafka_config(subscriptions.first))
         listener = RebalanceListener.new(@config.consumer_class, @instrumenter)
         consumer_config.consumer_rebalance_listener = listener
         consumer = consumer_config.consumer
         listener.rdkafka_consumer = consumer
 
         @instrumenter.instrument('join_group') do
-          consumer.subscribe current_subscription.topic
+          consumer.subscribe(*subscriptions.map(&:topic))
         end
         consumer
       end
@@ -129,7 +131,7 @@ module Racecar
     # that's not needed and Kafka might rebalance if topics are not polled frequently
     # enough.
     def subscribe_all
-      @config.subscriptions.size.times do
+      @subscriptions_by_consumer.size.times do
         current
         select_next_consumer
       end
@@ -168,7 +170,7 @@ module Racecar
     rescue Rdkafka::RdkafkaError => e
       try += 1
       @instrumenter.instrument("poll_retry", try: try, rdkafka_time_limit: remain_ms, exception: e)
-      @logger.error "(try #{try}/#{MAX_POLL_TRIES}): Error for topic subscription #{current_subscription}: #{e}"
+      @logger.error "(try #{try}/#{MAX_POLL_TRIES}): Error for topic subscription(s) #{current_subscriptions.map(&:topic).join(", ")}: #{e}"
       raise if try >= MAX_POLL_TRIES
       retry
     end
@@ -199,8 +201,23 @@ module Racecar
       return nil, nil
     end
 
-    def current_subscription
-      @config.subscriptions[@consumer_id_iterator.peek]
+    # One entry per rdkafka consumer to create. With single_consumer enabled all
+    # subscriptions share one consumer; otherwise each subscription gets its own.
+    def subscriptions_by_consumer
+      return @config.subscriptions.map { |subscription| [subscription] } unless @config.single_consumer
+
+      settings = @config.subscriptions.map do |subscription|
+        [subscription.start_from_beginning, subscription.max_bytes_per_partition, subscription.additional_config]
+      end
+      if settings.uniq.size > 1
+        raise ArgumentError, "single_consumer requires all subscriptions to use the same start_from_beginning, max_bytes_per_partition and additional_config"
+      end
+
+      [@config.subscriptions]
+    end
+
+    def current_subscriptions
+      @subscriptions_by_consumer[@consumer_id_iterator.peek]
     end
 
     def reset_current_consumer

--- a/lib/racecar/rebalance_listener.rb
+++ b/lib/racecar/rebalance_listener.rb
@@ -14,7 +14,7 @@ module Racecar
     def on_partitions_assigned(rdkafka_topic_partition_list)
       event = Event.new(rdkafka_consumer: rdkafka_consumer, rdkafka_topic_partition_list: rdkafka_topic_partition_list)
 
-      instrument("partitions_assigned", partitions: event.partition_numbers) do
+      instrument("partitions_assigned", partitions: event.topic_partition_numbers.values.flatten) do
         consumer_class.on_partitions_assigned(event)
       end
     end
@@ -22,7 +22,7 @@ module Racecar
     def on_partitions_revoked(rdkafka_topic_partition_list)
       event = Event.new(rdkafka_consumer: rdkafka_consumer, rdkafka_topic_partition_list: rdkafka_topic_partition_list)
 
-      instrument("partitions_revoked", partitions: event.partition_numbers) do
+      instrument("partitions_revoked", partitions: event.topic_partition_numbers.values.flatten) do
         consumer_class.on_partitions_revoked(event)
       end
     end
@@ -40,11 +40,18 @@ module Racecar
       end
 
       def topic_name
+        ensure_single_topic!("topic_name")
         __rdkafka_topic_partition_list.to_h.keys.first
       end
 
       def partition_numbers
+        ensure_single_topic!("partition_numbers")
         __rdkafka_topic_partition_list.to_h.values.flatten.map(&:partition)
+      end
+
+      # {topic name => [partition numbers]} for every topic in the event.
+      def topic_partition_numbers
+        __rdkafka_topic_partition_list.to_h.transform_values { |partitions| partitions.map(&:partition) }
       end
 
       def empty?
@@ -53,6 +60,14 @@ module Racecar
 
       # API private and not guaranteed stable
       attr_reader :__rdkafka_topic_partition_list, :__rdkafka_consumer
+
+      private
+
+      def ensure_single_topic!(method_name)
+        return if __rdkafka_topic_partition_list.to_h.size <= 1
+
+        raise Racecar::Error, "##{method_name} is ambiguous for a rebalance event spanning multiple topics; use #topic_partition_numbers"
+      end
     end
   end
 end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -73,7 +73,8 @@ module Racecar
         @instrumenter.instrument("main_loop", instrumentation_payload) do
           case process_method
           when :batch then
-            msg_per_part = consumer.batch_poll(config.max_wait_time_ms).group_by(&:partition)
+            msg_per_part = consumer.batch_poll(config.max_wait_time_ms)
+              .group_by { |message| [message.topic, message.partition] }
             msg_per_part.each_value do |messages|
               process_batch(messages)
             end

--- a/spec/consumer_set_spec.rb
+++ b/spec/consumer_set_spec.rb
@@ -335,6 +335,46 @@ RSpec.describe Racecar::ConsumerSet do
     end
   end
 
+  context "A consumer with multiple subscriptions in single consumer mode" do
+    let(:subscriptions) { [ subscription("feature"), subscription("profile") ] }
+
+    before { config.single_consumer = true }
+
+    it "subscribes a single consumer to all topics upon first use" do
+      consumer_set.current
+
+      expect(rdconsumer).to have_received(:subscribe).with("feature", "profile")
+      expect(Rdkafka::Config).to have_received(:new).once
+    end
+
+    it "creates only one consumer for all subscriptions" do
+      consumer_set.subscribe_all
+
+      expect(Rdkafka::Config).to have_received(:new).once
+    end
+
+    it "keeps polling the same consumer" do
+      config.multi_subscription_strategy = "round-robin"
+      allow(rdconsumer).to receive(:poll).and_return(:msg1, :msg2)
+
+      consumer_set.poll(100)
+      consumer_set.poll(100)
+
+      expect(Rdkafka::Config).to have_received(:new).once
+      expect(rdconsumer).to have_received(:poll).twice
+    end
+
+    context "when subscriptions differ in their settings" do
+      let(:subscriptions) do
+        [ subscription("feature"), Racecar::Consumer::Subscription.new("profile", false, 1048576, {}) ]
+      end
+
+      it "raises an exception" do
+        expect { consumer_set }.to raise_error(ArgumentError, /single_consumer/)
+      end
+    end
+  end
+
   context "A consumer with multiple subscriptions" do
     let(:subscriptions) { [ subscription("feature"), subscription("profile"), subscription("account") ] }
     let(:rdconsumer1)   { double("rdconsumer_feature", subscribe: true, assignment: tpl(subscriptions[0])) }

--- a/spec/rebalance_listener_spec.rb
+++ b/spec/rebalance_listener_spec.rb
@@ -31,6 +31,41 @@ RSpec.describe Racecar::RebalanceListener do
     end
   end
 
+  describe "single-topic accessors on a multi-topic event" do
+    let(:partitions_by_topic_hash) do
+      {
+        "topic_a" => [double(:partition, partition: 0)],
+        "topic_b" => [double(:partition, partition: 1)],
+      }
+    end
+
+    it "raises from topic_name and partition_numbers instead of pairing them inconsistently" do
+      listener.on_partitions_assigned(rdkafka_topic_partition_list)
+
+      expect(consumer_class).to have_received(:on_partitions_assigned) do |rebalance_event|
+        expect { rebalance_event.topic_name }.to raise_error(Racecar::Error, /topic_partition_numbers/)
+        expect { rebalance_event.partition_numbers }.to raise_error(Racecar::Error, /topic_partition_numbers/)
+      end
+    end
+  end
+
+  describe "#topic_partition_numbers" do
+    let(:partitions_by_topic_hash) do
+      {
+        "topic_a" => [double(:partition, partition: 0), double(:partition, partition: 1)],
+        "topic_b" => [double(:partition, partition: 2)],
+      }
+    end
+
+    it "exposes the partitions of every topic in the event" do
+      listener.on_partitions_assigned(rdkafka_topic_partition_list)
+
+      expect(consumer_class).to have_received(:on_partitions_assigned) do |rebalance_event|
+        expect(rebalance_event.topic_partition_numbers).to eq("topic_a" => [0, 1], "topic_b" => [2])
+      end
+    end
+  end
+
   describe "#on_partitions_revoked" do
     it "calls the consumer class' callback passing the rebalance event" do
       listener.on_partitions_revoked(rdkafka_topic_partition_list)

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -99,25 +99,35 @@ class FakeConsumer
     @kafka = kafka
     @runner = runner
 
-    @topic = nil
-    @committed_offset = "not set yet"
-    @internal_offset = 0
+    @topics = nil
+    @committed_offsets = {}
+    @internal_offsets = Hash.new(0)
     @_paused = false
     @previous_messages = []
 
     @poll_count = 0
   end
 
-  attr_reader :topic, :committed_offset, :_paused
+  attr_reader :_paused, :committed_offsets
 
-  def subscribe(topic, **)
-    @topic ||= topic
-    raise "cannot handle more than one topic per consumer" if @topic != topic
+  def topic
+    @topics&.first
+  end
+
+  # Single-topic view used by the offset handling shared examples.
+  def committed_offset
+    @committed_offsets.fetch(topic, "not set yet")
+  end
+
+  def subscribe(*topics, **)
+    @topics ||= topics
+    raise "cannot change the subscription of a consumer" if @topics != topics
+    @poll_topic_iterator = @topics.cycle
   end
 
   def assignment
     Rdkafka::Consumer::TopicPartitionList.new.tap do |tpl|
-      tpl.add_topic(topic, 1)
+      (@topics || []).each { |topic| tpl.add_topic(topic, 1) }
     end
   end
 
@@ -126,9 +136,16 @@ class FakeConsumer
     # exactly stop when reading from multiple topics
     @runner.stop if (@poll_count += 1) >= 10
 
-    msg = @kafka.received_messages[@topic][@internal_offset]
-    @internal_offset += 1
-    msg
+    # round-robin across subscribed topics so no topic starves
+    @topics.size.times do
+      topic = @poll_topic_iterator.next
+      msg = @kafka.received_messages[topic][@internal_offsets[topic]]
+      next unless msg
+
+      @internal_offsets[topic] += 1
+      return msg
+    end
+    nil
   end
 
   def commit(partitions, async)
@@ -138,9 +155,9 @@ class FakeConsumer
   end
 
   def store_offset(message)
-    raise "storing offset on wrong consumer. own topic: #{@topic} vs #{message.topic}" if @topic != message.topic
+    raise "storing offset on wrong consumer. own topics: #{@topics} vs #{message.topic}" unless @topics.include?(message.topic)
     # + 1 as per: https://github.com/edenhill/librdkafka/wiki/Consumer-offset-management#terminology
-    @internal_offset = @committed_offset = message.offset + 1
+    @internal_offsets[message.topic] = @committed_offsets[message.topic] = message.offset + 1
   end
 
   def pause(tpl)
@@ -154,8 +171,8 @@ class FakeConsumer
   end
 
   def seek(message)
-    raise "seeking on wrong consumer. own topic: #{@topic} vs #{message.topic}" if @topic != message.topic
-    @internal_offset = message.offset
+    raise "seeking on wrong consumer. own topics: #{@topics} vs #{message.topic}" unless @topics.include?(message.topic)
+    @internal_offsets[message.topic] = message.offset
   end
 end
 
@@ -652,6 +669,45 @@ RSpec.describe Racecar::Runner do
         kafka.deliver_message(StandardError.new("surprise"), topic: "greetings")
         expect { runner.run }.to change { instrumenter.event_raised_errors?("process_batch") }.to(true)
       end
+    end
+  end
+
+  context "with single_consumer mode and a consumer with multiple subscriptions" do
+    let(:processor) { TestMultiConsumer.new }
+
+    before { config.single_consumer = true }
+
+    it "processes messages from all topics through one consumer" do
+      kafka.deliver_message("hello", topic: "greetings")
+      kafka.deliver_message("world", topic: "second")
+
+      runner.run
+
+      expect(kafka.consumers.size).to eq 1
+      expect(processor.messages.map(&:value)).to contain_exactly("hello", "world")
+    end
+
+    it "stores offsets per topic on the shared consumer" do
+      kafka.deliver_message("hello", topic: "greetings")
+      kafka.deliver_message("world", topic: "second")
+
+      runner.run
+
+      expect(kafka.consumers.first.committed_offsets).to eq("greetings" => 1, "second" => 1)
+    end
+
+    it "splits a poll spanning topics into one batch per topic and partition" do
+      kafka.deliver_message("hello", topic: "greetings")
+      kafka.deliver_message("world", topic: "second")
+
+      allow(instrumenter).to receive(:instrument).and_call_original
+
+      runner.run
+
+      expect(instrumenter).to have_received(:instrument)
+        .with("process_batch", hash_including(topic: "greetings", message_count: 1))
+      expect(instrumenter).to have_received(:instrument)
+        .with("process_batch", hash_including(topic: "second", message_count: 1))
     end
   end
 


### PR DESCRIPTION
Hi. We've noticed an issue with how racecar handles subscription to multiple topics. It creates one rdkafka consumer per subscribed topic.

Consumer config:

```
  subscribes_to('copart_test_a', 'copart_test_b', additional_config: { 'partition.assignment.strategy' => 'range' })
```

It shows the following kafka group members:

```
GROUP           CONSUMER-ID                                    HOST            CLIENT-ID       #PARTITIONS     ASSIGNMENT
copart-test     core_apis-21b9f95a-4201-4451-96f4-20adfe203c26 /192.168.65.1   core_apis       12              copart_test_a(0,1,2,3,4,5,6,7,8,9,10,11)
copart-test     core_apis-5ad83747-af88-417f-b6c9-1f170ff00d27 /192.168.65.1   core_apis       12              copart_test_b(0,1,2,3,4,5,6,7,8,9,10,11)
```

`CONSUMER-ID` are distinct, meaning that racecar creates separate kafka consumer for each subscribed topic. 

As a result despite using: ` 'partition.assignment.strategy' => 'range'` there's no guarantee that partitions from different topics will be colocated. It makes adding horizontal scalability by having multiple consumers working on colocated partitions from different topics impossible. kafka assigns partitions based on sorted member ID which is random. I've replicated the same consumer getting partitions `0-5` from topic `copart_test_a` and `6-11` from `copart_test_b`.

In theory it's possible to improve colocation by prefixing consumer id by sortable prefix, but I would not like to bet production colocation on this. It's possible for one consumer to e.g. timeout, and colocation would be broken.

This PR adds an optional `single_consumer` config which uses a single consumer for all topics. So the members group assignment is now:

```
GROUP           CONSUMER-ID                                    HOST            CLIENT-ID       #PARTITIONS     ASSIGNMENT
copart-test     core_apis-b1ec9fec-fec9-4522-b8e2-5a92ca9b9818 /192.168.65.1   core_apis       24              copart_test_a(0,1,2,3,4,5,6,7,8,9,10,11), copart_test_b(0,1,2,3,4,5,6,7,8,9,10,11)
```

A single consumer subscribed to multiple topics, ensuring the partitions colocation when using `'partition.assignment.strategy' => 'range'`.

Happy to adjust naming or approach.